### PR TITLE
feat: add Shennong Bencao herb index page

### DIFF
--- a/books.html
+++ b/books.html
@@ -33,6 +33,9 @@
                     <a href="index.html#herbs" class="nav-link" data-zh="本草图鉴" data-en="Herb Catalog">本草图鉴</a>
                 </li>
                 <li class="nav-item">
+                    <a href="zhongyao.html" class="nav-link" data-zh="神农本草" data-en="Shennong Herbs">神农本草</a>
+                </li>
+                <li class="nav-item">
                     <a href="books.html" class="nav-link active" data-zh="中医好书" data-en="TCM Books">中医好书</a>
                 </li>
                 <li class="nav-item">

--- a/data/shennong-herbs.js
+++ b/data/shennong-herbs.js
@@ -1,0 +1,34 @@
+const shennongHerbs = [
+  {
+    id: 1,
+    name: "人参",
+    grade: "上品",
+    classicalText: "人参，味甘，微寒。主补五脏，安精神，止惊悸，除邪气，明目开心益智，久服轻身延年。"
+  },
+  {
+    id: 2,
+    name: "干地黄",
+    grade: "上品",
+    classicalText: "干地黄，味甘，寒。主折跌绝筋，破积血，寒热，五劳，诸不足，补中益气，强阴。久服轻身益气。"
+  },
+  {
+    id: 3,
+    name: "干姜",
+    grade: "上品",
+    classicalText: "干姜，味辛，温。主胸满咳逆上气，温中止血，除寒湿痹，痿躄，脚逆。久服温中。"
+  },
+  {
+    id: 4,
+    name: "桂枝",
+    grade: "上品",
+    classicalText: "桂枝，味辛，温。主上气咳逆，温中，通脉，止汗，除风寒湿痹。久服补中，通神。"
+  },
+  {
+    id: 5,
+    name: "甘草",
+    grade: "上品",
+    classicalText: "甘草，味甘，平。主五脏六腑寒热邪气，坚筋骨，长肌肉，倍气力，金疮肿痛。久服轻身延年。"
+  }
+];
+
+export default shennongHerbs;

--- a/game.html
+++ b/game.html
@@ -33,6 +33,9 @@
                     <a href="index.html#herbs" class="nav-link" data-zh="本草图鉴" data-en="Herb Catalog">本草图鉴</a>
                 </li>
                 <li class="nav-item">
+                    <a href="zhongyao.html" class="nav-link" data-zh="神农本草" data-en="Shennong Herbs">神农本草</a>
+                </li>
+                <li class="nav-item">
                     <a href="books.html" class="nav-link" data-zh="中医好书" data-en="TCM Books">中医好书</a>
                 </li>
                 <li class="nav-item">

--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@
                 <li class="nav-item"><a href="#consultation" class="nav-link">在线咨询</a></li>
                 <li class="nav-item"><a href="#about" class="nav-link">关于我们</a></li>
                 <li class="nav-item"><a href="#contact" class="nav-link">联系我们</a></li>
+                <li class="nav-item"><a href="zhongyao.html" class="nav-link">神农本草</a></li>
                 <li class="nav-item"><a href="postal-codes.html" class="nav-link">邮编查询</a></li>
             </ul>
             <div class="nav-actions">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -36,4 +36,10 @@
         <changefreq>monthly</changefreq>
         <priority>0.6</priority>
     </url>
+    <url>
+        <loc>https://traditionalchinesemedicine.online/zhongyao.html</loc>
+        <lastmod>2024-01-15</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.9</priority>
+    </url>
 </urlset>

--- a/styles.css
+++ b/styles.css
@@ -1297,3 +1297,273 @@ body {
         margin: 0 10px;
     }
 }
+/* 神农本草经页面 */
+.herb-archive-page {
+    background: #f7f8f3;
+}
+
+.hero-herb {
+    background: linear-gradient(120deg, rgba(34, 139, 34, 0.85), rgba(76, 175, 80, 0.85)), url('https://images.unsplash.com/photo-1524592094714-0f0654e20314?w=1600&auto=format&fit=crop&q=80') center/cover;
+    color: #fff;
+    text-align: center;
+    padding: 140px 20px 100px;
+}
+
+.hero-herb .page-title {
+    font-size: 2.8rem;
+    margin-bottom: 20px;
+}
+
+.hero-herb .page-subtitle {
+    font-size: 1.2rem;
+    max-width: 720px;
+    margin: 0 auto;
+    line-height: 1.8;
+}
+
+.herb-controls {
+    padding: 40px 0;
+}
+
+.control-grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    align-items: end;
+}
+
+.control-group label,
+.control-label {
+    font-weight: 600;
+    display: block;
+    margin-bottom: 12px;
+    color: #1b5e20;
+}
+
+.control-group input[type="search"] {
+    width: 100%;
+    padding: 14px 16px;
+    border-radius: 12px;
+    border: 1px solid #c8d6c3;
+    background: #fff;
+    font-size: 1rem;
+    transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.control-group input[type="search"]:focus {
+    outline: none;
+    border-color: #4CAF50;
+    box-shadow: 0 0 0 3px rgba(76, 175, 80, 0.2);
+}
+
+.grade-tabs {
+    display: inline-flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.grade-tab {
+    padding: 10px 18px;
+    border-radius: 999px;
+    border: 1px solid #a5d6a7;
+    background: #fff;
+    color: #2e7d32;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.grade-tab:hover {
+    transform: translateY(-1px);
+}
+
+.grade-tab.active {
+    background: linear-gradient(135deg, #4CAF50, #2e7d32);
+    color: #fff;
+    border-color: transparent;
+    box-shadow: 0 8px 20px rgba(76, 175, 80, 0.25);
+}
+
+.control-hint {
+    margin-top: 18px;
+    color: #5f6f52;
+    font-size: 0.95rem;
+}
+
+.herb-list-section {
+    padding: 20px 0 80px;
+}
+
+.herb-stats {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    margin-bottom: 32px;
+}
+
+.stat-card {
+    background: #fff;
+    border-radius: 16px;
+    padding: 20px;
+    box-shadow: 0 10px 30px rgba(76, 175, 80, 0.1);
+    position: relative;
+    overflow: hidden;
+}
+
+.stat-card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(76, 175, 80, 0.08), rgba(46, 125, 50, 0.12));
+    z-index: -1;
+}
+
+.stat-label {
+    font-size: 0.95rem;
+    color: #4f5b48;
+}
+
+.stat-value {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #2e7d32;
+    display: block;
+    margin-top: 8px;
+}
+
+.stat-sub {
+    font-size: 0.85rem;
+    color: #7a8b70;
+}
+
+.herb-list {
+    display: grid;
+    gap: 24px;
+}
+
+.herb-entry {
+    background: #fff;
+    border-radius: 18px;
+    padding: 24px;
+    box-shadow: 0 15px 35px rgba(0, 0, 0, 0.08);
+    border: 1px solid rgba(76, 175, 80, 0.12);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.herb-entry:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.12);
+}
+
+.herb-entry__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 18px;
+    gap: 16px;
+}
+
+.herb-entry__grade {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    background: rgba(76, 175, 80, 0.12);
+    color: #2e7d32;
+}
+
+.herb-entry__name {
+    font-size: 1.6rem;
+    margin-top: 10px;
+    margin-bottom: 0;
+    color: #1b4332;
+}
+
+.herb-entry__id {
+    font-family: 'Fira Code', monospace;
+    background: #1b4332;
+    color: #fff;
+    border-radius: 8px;
+    padding: 6px 10px;
+    font-size: 0.85rem;
+}
+
+.herb-entry__meta {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    margin-bottom: 16px;
+}
+
+.herb-entry__meta dt {
+    font-weight: 700;
+    color: #2e7d32;
+    margin-bottom: 6px;
+}
+
+.herb-entry__meta dd {
+    margin: 0;
+    color: #4f5b48;
+    line-height: 1.7;
+}
+
+.herb-entry__source {
+    border: 1px solid rgba(76, 175, 80, 0.2);
+    border-radius: 12px;
+    padding: 14px 18px;
+    background: rgba(76, 175, 80, 0.05);
+}
+
+.herb-entry__source summary {
+    font-weight: 600;
+    cursor: pointer;
+    color: #2e7d32;
+}
+
+.herb-entry__source p {
+    margin-top: 12px;
+    color: #3d4d39;
+    line-height: 1.8;
+}
+
+.empty-state {
+    text-align: center;
+    padding: 60px 20px;
+    color: #5f6f52;
+    font-size: 1.1rem;
+    background: rgba(76, 175, 80, 0.08);
+    border-radius: 18px;
+}
+
+.page-footer {
+    background: linear-gradient(135deg, #1b4332, #2e7d32);
+    color: #fff;
+    padding: 40px 0;
+    text-align: center;
+}
+
+.page-footer .footer-note {
+    margin-top: 10px;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+@media (max-width: 768px) {
+    .hero-herb {
+        padding: 120px 16px 80px;
+    }
+
+    .hero-herb .page-title {
+        font-size: 2.2rem;
+    }
+
+    .herb-entry {
+        padding: 20px;
+    }
+
+    .herb-entry__meta {
+        grid-template-columns: 1fr;
+    }
+}

--- a/timer.html
+++ b/timer.html
@@ -33,6 +33,9 @@
                     <a href="index.html#herbs" class="nav-link" data-zh="本草图鉴" data-en="Herb Catalog">本草图鉴</a>
                 </li>
                 <li class="nav-item">
+                    <a href="zhongyao.html" class="nav-link" data-zh="神农本草" data-en="Shennong Herbs">神农本草</a>
+                </li>
+                <li class="nav-item">
                     <a href="books.html" class="nav-link" data-zh="中医好书" data-en="TCM Books">中医好书</a>
                 </li>
                 <li class="nav-item">

--- a/zhongyao.html
+++ b/zhongyao.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>神农本草经中药图鉴 - 性味主治速查</title>
+    <meta name="description" content="检索《神农本草经》记载的中药性味、毒性与功效，按上品、中品、下品分类展示全书内容。">
+    <meta name="keywords" content="神农本草经,中药,药性,性味,毒性,上品,中品,下品">
+    <link rel="stylesheet" href="styles.css">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <meta name="google-adsense-account" content="ca-pub-8794607118520437">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437" crossorigin="anonymous"></script>
+</head>
+<body class="herb-archive-page">
+    <nav class="navbar">
+        <div class="nav-container">
+            <div class="nav-logo">
+                <i class="fas fa-leaf"></i>
+                <span>神农百草</span>
+            </div>
+            <ul class="nav-menu">
+                <li class="nav-item"><a href="index.html#herbs" class="nav-link">本草图鉴</a></li>
+                <li class="nav-item"><a href="zhongyao.html" class="nav-link active">神农本草</a></li>
+                <li class="nav-item"><a href="books.html" class="nav-link">中医好书</a></li>
+                <li class="nav-item"><a href="game.html" class="nav-link">小游戏</a></li>
+                <li class="nav-item"><a href="timer.html" class="nav-link">倒计时</a></li>
+            </ul>
+            <div class="hamburger">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </div>
+        </div>
+    </nav>
+
+    <header class="page-header hero-herb">
+        <div class="container">
+            <h1 class="page-title">《神农本草经》药性全录</h1>
+            <p class="page-subtitle">按上品、中品、下品分类整理365味本草的性味、毒性与主治原文，支持快速检索与筛选。</p>
+        </div>
+    </header>
+
+    <main class="page-content">
+        <section class="herb-controls">
+            <div class="container">
+                <div class="control-grid">
+                    <div class="control-group">
+                        <label for="herbSearch"><i class="fas fa-search"></i> 搜索药名或功效</label>
+                        <input type="search" id="herbSearch" placeholder="输入药名、功效关键字或经文片段...">
+                    </div>
+                    <div class="control-group">
+                        <span class="control-label"><i class="fas fa-layer-group"></i> 三品筛选</span>
+                        <div class="grade-tabs">
+                            <button type="button" class="grade-tab active" data-grade="all">全部</button>
+                            <button type="button" class="grade-tab" data-grade="上品">上品</button>
+                            <button type="button" class="grade-tab" data-grade="中品">中品</button>
+                            <button type="button" class="grade-tab" data-grade="下品">下品</button>
+                        </div>
+                    </div>
+                </div>
+                <p class="control-hint">数据来源：《神农本草经》原文。性味、毒性、主治等字段基于经典记载自动拆分。</p>
+            </div>
+        </section>
+
+        <section class="herb-list-section">
+            <div class="container">
+                <div id="herbStats" class="herb-stats"></div>
+                <div id="herbList" class="herb-list" aria-live="polite"></div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="page-footer">
+        <div class="container">
+            <p>© 2024 神农百草 · 《神农本草经》药性整理</p>
+            <p class="footer-note">久服轻身延年——谨遵经典，辨证施治。</p>
+        </div>
+    </footer>
+
+    <script type="module" src="zhongyao.js"></script>
+</body>
+</html>

--- a/zhongyao.js
+++ b/zhongyao.js
@@ -1,0 +1,159 @@
+import shennongHerbs from './data/shennong-herbs.js';
+
+const gradeOrder = ['上品', '中品', '下品'];
+
+document.addEventListener('DOMContentLoaded', () => {
+    const listEl = document.getElementById('herbList');
+    const statsEl = document.getElementById('herbStats');
+    const searchInput = document.getElementById('herbSearch');
+    const gradeTabs = document.querySelectorAll('.grade-tab');
+
+    let activeGrade = 'all';
+
+    gradeTabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+            gradeTabs.forEach(btn => btn.classList.remove('active'));
+            tab.classList.add('active');
+            activeGrade = tab.dataset.grade;
+            render();
+        });
+    });
+
+    searchInput.addEventListener('input', () => {
+        render();
+    });
+
+    function parseEntry(entryText) {
+        const info = {
+            taste: '',
+            toxicity: '',
+            mainFunctions: '',
+            extra: ''
+        };
+
+        if (!entryText) return info;
+
+        const normalized = entryText.replace(/\s+/g, '');
+        const toxicityMatch = normalized.match(/(无毒|有毒|小毒|大毒|微毒)/);
+        if (toxicityMatch) {
+            info.toxicity = toxicityMatch[1];
+        }
+
+        const tasteMatch = normalized.match(/味([^。；]+)/);
+        if (tasteMatch) {
+            let tasteText = tasteMatch[1];
+            if (info.toxicity && tasteText.includes(info.toxicity)) {
+                tasteText = tasteText.replace(info.toxicity, '');
+            }
+            info.taste = tasteText.replace(/^[，。]/, '').replace(/。$/, '');
+        }
+
+        const mainMatch = normalized.match(/主([^。]+)/);
+        if (mainMatch) {
+            info.mainFunctions = mainMatch[1]
+                .replace(/^[，。]/, '')
+                .replace(/。$/, '')
+                .replace(/久服.*$/, '')
+                .replace(/主/, '');
+        }
+
+        const extraMatch = normalized.match(/久服[^。]+/);
+        if (extraMatch) {
+            info.extra = extraMatch[0];
+        }
+
+        return info;
+    }
+
+    function getFilteredHerbs() {
+        const keyword = searchInput.value.trim().toLowerCase();
+        return shennongHerbs.filter(item => {
+            const gradeOk = activeGrade === 'all' || item.grade === activeGrade;
+            if (!gradeOk) return false;
+            if (!keyword) return true;
+            const haystack = `${item.name}${item.classicalText}`.toLowerCase();
+            return haystack.includes(keyword);
+        }).sort((a, b) => {
+            if (a.grade === b.grade) {
+                return a.id - b.id;
+            }
+            return gradeOrder.indexOf(a.grade) - gradeOrder.indexOf(b.grade);
+        });
+    }
+
+    function updateStats(filtered) {
+        const total = shennongHerbs.length;
+        const gradeCounts = gradeOrder.reduce((acc, grade) => {
+            acc[grade] = shennongHerbs.filter(item => item.grade === grade).length;
+            return acc;
+        }, {});
+
+        const filteredCounts = gradeOrder.reduce((acc, grade) => {
+            acc[grade] = filtered.filter(item => item.grade === grade).length;
+            return acc;
+        }, {});
+
+        statsEl.innerHTML = `
+            <div class="stat-card">
+                <span class="stat-label">收录总数</span>
+                <span class="stat-value">${total}</span>
+            </div>
+            ${gradeOrder.map(grade => `
+                <div class="stat-card">
+                    <span class="stat-label">${grade}</span>
+                    <span class="stat-value">${gradeCounts[grade]}</span>
+                    <span class="stat-sub">当前筛选：${filteredCounts[grade]}</span>
+                </div>
+            `).join('')}
+        `;
+    }
+
+    function render() {
+        const filtered = getFilteredHerbs();
+        updateStats(filtered);
+
+        listEl.innerHTML = '';
+
+        if (!filtered.length) {
+            listEl.innerHTML = `<p class="empty-state">未找到符合条件的本草，请调整筛选或关键词。</p>`;
+            return;
+        }
+
+        filtered.forEach(item => {
+            const info = parseEntry(item.classicalText);
+            const card = document.createElement('article');
+            card.className = 'herb-entry';
+            card.innerHTML = `
+                <header class="herb-entry__header">
+                    <div>
+                        <span class="herb-entry__grade">${item.grade}</span>
+                        <h2 class="herb-entry__name">${item.name}</h2>
+                    </div>
+                    <span class="herb-entry__id">#${String(item.id).padStart(3, '0')}</span>
+                </header>
+                <dl class="herb-entry__meta">
+                    <div>
+                        <dt>性味</dt>
+                        <dd>${info.taste || '经典中未明述'}</dd>
+                    </div>
+                    <div>
+                        <dt>毒性</dt>
+                        <dd>${info.toxicity || '经典中未标注'}</dd>
+                    </div>
+                    <div>
+                        <dt>主治</dt>
+                        <dd>${info.mainFunctions || '详见原文'}</dd>
+                    </div>
+                    ${info.extra ? `<div><dt>久服</dt><dd>${info.extra}</dd></div>` : ''}
+                </dl>
+                <details class="herb-entry__source">
+                    <summary>《神农本草经》原文</summary>
+                    <p>${item.classicalText}</p>
+                </details>
+            `;
+            listEl.appendChild(card);
+        });
+    }
+
+    render();
+});


### PR DESCRIPTION
## Summary
- add a dedicated `zhongyao.html` page with search, filtering, and source text display for Shennong Bencao herbs
- introduce a reusable rendering script and starter dataset plus styling for the new archive view
- surface the new page in site navigation and sitemap for cross-page access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd52e008f08321845b5bfe486e4c83