### PR TITLE
Remove Shennong herb images and add badges

### DIFF
--- a/homepage-herbs.js
+++ b/homepage-herbs.js
@@ -95,24 +95,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const createHerbCard = herb => {
     const info = parseEntry(herb.classicalText);
     const card = document.createElement('article');
-    card.className = 'herb-card';
+    card.className = 'herb-card herb-card--text-only';
     card.dataset.grade = herb.grade;
 
     const wrapper = document.createElement('div');
     wrapper.className = 'herb-card__body';
 
-    const imageBox = document.createElement('div');
-    imageBox.className = 'herb-image';
-    if (herb.image) {
-      const img = document.createElement('img');
-      img.src = herb.image;
-      img.alt = `${herb.name}图`; 
-      img.loading = 'lazy';
-      imageBox.appendChild(img);
-    } else {
-      imageBox.classList.add('herb-image--empty');
-      imageBox.innerHTML = '<span class="herb-image__placeholder"><i class="fas fa-leaf" aria-hidden="true"></i></span>';
-    }
+    const badge = document.createElement('div');
+    badge.className = 'herb-card__badge';
+    badge.textContent = herb.name.length > 2 ? herb.name.slice(0, 2) : herb.name;
+    badge.setAttribute('aria-hidden', 'true');
+    badge.title = herb.name;
+    wrapper.appendChild(badge);
 
     const content = document.createElement('div');
     content.className = 'herb-card__content';
@@ -167,7 +161,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     content.appendChild(classic);
 
-    wrapper.appendChild(imageBox);
     wrapper.appendChild(content);
     card.appendChild(wrapper);
 

--- a/styles.css
+++ b/styles.css
@@ -585,42 +585,24 @@ body {
     display: flex;
     flex-direction: column;
     height: 100%;
+    gap: 1.2rem;
 }
 
-.herb-image {
-    position: relative;
-    padding-top: 58%;
-    overflow: hidden;
-    background: linear-gradient(135deg, rgba(76, 175, 80, 0.12), rgba(46, 125, 50, 0.12));
-}
-
-.herb-image img {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-}
-
-.herb-image--empty {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.herb-image__placeholder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-    font-size: 2rem;
-    color: rgba(76, 175, 80, 0.45);
+.herb-card__badge {
+    align-self: flex-start;
+    margin: 1.6rem 0 0 1.8rem;
+    padding: 0.55rem 1.1rem;
+    border-radius: 12px;
+    background: linear-gradient(135deg, #4CAF50, #2e7d32);
+    color: #fff;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    font-size: 0.95rem;
+    box-shadow: 0 12px 24px rgba(76, 175, 80, 0.25);
 }
 
 .herb-card__content {
-    padding: 1.8rem;
+    padding: 0 1.8rem 1.8rem;
     display: flex;
     flex-direction: column;
     gap: 1rem;
@@ -783,8 +765,14 @@ body {
         text-align: left;
     }
 
+    .herb-card__badge {
+        margin: 1.2rem 0 0 1.5rem;
+        font-size: 0.9rem;
+        padding: 0.45rem 0.9rem;
+    }
+
     .herb-card__content {
-        padding: 1.5rem;
+        padding: 0 1.5rem 1.5rem;
     }
 
     .herb-card__header {


### PR DESCRIPTION
## Summary
- stop rendering external herb photos in the homepage Shennong section and rely on text data only
- introduce decorative herb name badges and update layout spacing for the text-only cards

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ceaebf0a6083219f976327255b6455