### PR TITLE
Add Babu Jingang Gong practice guidance

### DIFF
--- a/babu-jingang-gong.html
+++ b/babu-jingang-gong.html
@@ -1,0 +1,395 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>八部金刚功精修笔记 | 传统中医诊所</title>
+    <meta name="description" content="以老练功者的视角，拆解八部金刚功的桩法、呼吸、意守与八式次第，提供日课安排与自我校准要点。">
+    <meta name="keywords" content="八部金刚功, 少林内功, 气功, 站桩, 呼吸法, 中医养生">
+    <meta property="og:title" content="八部金刚功精修笔记">
+    <meta property="og:description" content="传授八部金刚功的内外修炼次第，从桩稳、气整到神领，呈现实战心得。">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://traditionalchinesemedicine.online/babu-jingang-gong.html">
+    <meta property="og:image" content="https://images.unsplash.com/photo-1556817411-31ae72fa3ea0?auto=format&fit=crop&w=1600&q=80">
+    <link rel="stylesheet" href="styles.css">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <meta name="google-adsense-account" content="ca-pub-8794607118520437">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CXH17REJKN"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-CXH17REJKN');
+    </script>
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-container">
+            <div class="nav-logo">
+                <i class="fas fa-leaf"></i>
+                <span>传统中医诊所</span>
+            </div>
+            <ul class="nav-menu">
+                <li class="nav-item"><a href="index.html#home" class="nav-link">首页</a></li>
+                <li class="nav-item"><a href="index.html#books" class="nav-link">好书推荐</a></li>
+                <li class="nav-item"><a href="index.html#about" class="nav-link">关于我们</a></li>
+                <li class="nav-item"><a href="zhongyao.html" class="nav-link">神农本草</a></li>
+                <li class="nav-item"><a href="babu-jingang-gong.html" class="nav-link active">八部金刚功</a></li>
+            </ul>
+            <div class="nav-actions">
+                <button class="bookmark-btn" id="bookmarkBtn" title="收藏页面">
+                    <i class="fas fa-bookmark"></i>
+                    <span>收藏</span>
+                </button>
+            </div>
+            <div class="hamburger">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </div>
+        </div>
+    </nav>
+
+    <main>
+        <section class="practice-hero">
+            <div class="container">
+                <div class="practice-hero-content">
+                    <span class="practice-hero-eyebrow">老功者的实战心得</span>
+                    <h1 class="practice-hero-title">八部金刚功精修笔记</h1>
+                    <p class="practice-hero-subtitle">以站桩为根、呼吸为轴、神行意领，打通筋骨皮膜，练就内外合一的金刚之身。</p>
+                    <ul class="practice-hero-points">
+                        <li><i class="fas fa-mountain"></i> 桩稳、气沉、意守三位一体的训练框架</li>
+                        <li><i class="fas fa-wind"></i> 八式细节拆解与动静相兼的内功节奏</li>
+                        <li><i class="fas fa-heart"></i> 老练功者的日课安排与自我校准清单</li>
+                    </ul>
+                    <div class="practice-hero-actions">
+                        <a href="#movements" class="btn btn-primary">直达八式拆解</a>
+                        <a href="#routine" class="btn btn-secondary">查看日课安排</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="practice-section practice-overview" id="overview">
+            <div class="container">
+                <div class="section-header">
+                    <p class="section-eyebrow">传承少林内养心法</p>
+                    <h2 class="section-title">功法总纲</h2>
+                    <p class="section-subtitle">八部金刚功源承禅门，讲究“立如松、坐如钟、行如风”。老练功者知：动作只是桥梁，真正的内涵在于筋骨、气息与神意的同频共振。</p>
+                </div>
+                <div class="essence-grid">
+                    <article class="essence-card">
+                        <h3>桩稳为根</h3>
+                        <p>起势就是修行。站桩三分钟，胜过匆匆练完一套。脚趾轻扣，涌泉如吸，尾闾如悬，脊柱拔长。</p>
+                        <ul class="essence-list">
+                            <li>脚掌三点均匀受力，膝不过趾</li>
+                            <li>丹田轻收，命门外撑，胸含背拔</li>
+                            <li>头顶虚领百会，舌抵上腭</li>
+                        </ul>
+                    </article>
+                    <article class="essence-card">
+                        <h3>呼吸为轴</h3>
+                        <p>吸纳非贪气量，而求气息绵长。以鼻吸鼻呼，配合动作起伏，出入以意领之。</p>
+                        <ul class="essence-list">
+                            <li>起势、展势时微吸，合势、回收时微呼</li>
+                            <li>呼长于吸，意守下丹田</li>
+                            <li>每式三息定势，气沉丹田后再行转换</li>
+                        </ul>
+                    </article>
+                    <article class="essence-card">
+                        <h3>意领气行</h3>
+                        <p>意到气到，气到力自随。意守不仅在丹田，更在手到、眼到、身到之处。</p>
+                        <ul class="essence-list">
+                            <li>双目平视，余光照见左右</li>
+                            <li>上肢展开时意送指尖，下沉时意归涌泉</li>
+                            <li>收势时默念“气归丹田”，培植内守</li>
+                        </ul>
+                    </article>
+                    <article class="essence-card">
+                        <h3>动静相依</h3>
+                        <p>动中求静，静中含动。八式衔接如行云流水，但每一式均有静守之刻。</p>
+                        <ul class="essence-list">
+                            <li>每式完成后静立三息，听心、听气</li>
+                            <li>动则全身合力，静则内观微动</li>
+                            <li>晨练偏动态，晚练偏静养</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="practice-section practice-movements" id="movements">
+            <div class="container">
+                <div class="section-header">
+                    <p class="section-eyebrow">八式精解</p>
+                    <h2 class="section-title">金刚八式的功与法</h2>
+                    <p class="section-subtitle">每一式皆有身体操作、呼吸节奏、意念走向与常见误区。善用这些要点，方能避免“练拳不练功，到老一场空”。</p>
+                </div>
+                <div class="movement-grid">
+                    <article class="movement-card">
+                        <h3>式一 · 金刚唤气</h3>
+                        <p>双手抱圆于丹田前，脚跟轻踮，随吸气托至胸前，再呼气落回。</p>
+                        <div class="movement-focus">主修：唤醒丹田，连通周身呼吸</div>
+                        <ul>
+                            <li>尾闾下垂，百会上领，脊柱如弓</li>
+                            <li>吸时意守命门，呼时意归丹田</li>
+                            <li>忌耸肩用力，保持肩沉肘垂</li>
+                        </ul>
+                    </article>
+                    <article class="movement-card">
+                        <h3>式二 · 金刚托天</h3>
+                        <p>掌心向上托至头顶，脚跟落地，呼气时缓缓下落，沉肘沉肩。</p>
+                        <div class="movement-focus">主修：开腋胸，疏理三焦</div>
+                        <ul>
+                            <li>手臂伸展不锁肘，腋下留空</li>
+                            <li>托举时脚心微吸地气</li>
+                            <li>落手时意念沿臂下沉入涌泉</li>
+                        </ul>
+                    </article>
+                    <article class="movement-card">
+                        <h3>式三 · 金刚开弓</h3>
+                        <p>左手如抱弓，右手如搭箭，开时吸气，合时呼气，左右各三次。</p>
+                        <div class="movement-focus">主修：调和肝胆，贯串肩胯</div>
+                        <ul>
+                            <li>开弓时肩胯同时展开，脊柱中正</li>
+                            <li>目光随箭指远方，意达中指尖</li>
+                            <li>勿只开手臂，须带动肩胛与胯根</li>
+                        </ul>
+                    </article>
+                    <article class="movement-card">
+                        <h3>式四 · 金刚托月</h3>
+                        <p>双掌托于体侧，自胯沿弧线托起至眉心，再翻掌按落。</p>
+                        <div class="movement-focus">主修：调理脾胃，涵养中气</div>
+                        <ul>
+                            <li>掌随身走，勿脱离身体中线</li>
+                            <li>起托时意守中丹田，按落时归命门</li>
+                            <li>保持呼吸绵长，无声胜有声</li>
+                        </ul>
+                    </article>
+                    <article class="movement-card">
+                        <h3>式五 · 金刚沉肘</h3>
+                        <p>双臂侧平举，肘尖向下沉，掌心向前推出，再收回丹田。</p>
+                        <div class="movement-focus">主修：沉肩坠肘，贯串手太阴肺经</div>
+                        <ul>
+                            <li>推出时如撕开帛布，意带胸背</li>
+                            <li>沉肘时气随臂落入掌心</li>
+                            <li>勿僵直手腕，保持指根圆撑</li>
+                        </ul>
+                    </article>
+                    <article class="movement-card">
+                        <h3>式六 · 金刚抚脊</h3>
+                        <p>双掌交替沿督脉抚下，配合躯干轻度屈伸，开合脊柱。</p>
+                        <div class="movement-focus">主修：温养督脉，灵活脊柱</div>
+                        <ul>
+                            <li>动作缓慢，意守脊柱一节一节展开</li>
+                            <li>呼气时脊柱沉松，吸气时轻轻拔伸</li>
+                            <li>腰部不可塌陷，保持尾闾内收</li>
+                        </ul>
+                    </article>
+                    <article class="movement-card">
+                        <h3>式七 · 金刚擎鼎</h3>
+                        <p>掌心朝上由胸前托出，再翻掌按回，如举鼎、如抱山。</p>
+                        <div class="movement-focus">主修：壮实臂力，贯通心包</div>
+                        <ul>
+                            <li>托举时吸气，肘不离肋</li>
+                            <li>按落时呼气，肩沉肘垂</li>
+                            <li>动作要圆，勿直进直出</li>
+                        </ul>
+                    </article>
+                    <article class="movement-card">
+                        <h3>式八 · 金刚归元</h3>
+                        <p>双掌叠放丹田，呼吸归于微细，意守内景，回味八式。</p>
+                        <div class="movement-focus">主修：收功归根，凝神养气</div>
+                        <ul>
+                            <li>全身轻轻微摆，察觉余震</li>
+                            <li>呼吸如存，如有若无</li>
+                            <li>以三遍自然呼吸结束，全身放松</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="practice-section practice-principles">
+            <div class="container">
+                <div class="section-header">
+                    <p class="section-eyebrow">内外三合</p>
+                    <h2 class="section-title">老练功者的三大内核</h2>
+                    <p class="section-subtitle">多年实修反复印证，八部金刚功的精髓凝练为“松沉、贯通、回光”三诀。遵循此纲，方能在动静之中守住真功。</p>
+                </div>
+                <div class="essence-grid">
+                    <article class="essence-card emphasis">
+                        <h3>松沉</h3>
+                        <p>松不是散，沉不是坠。全身从皮到筋到骨层层松开，沉气于脚掌，重心自然下落，方能立根。</p>
+                        <ul class="essence-list">
+                            <li>练前以脚趾抓地三息，提醒身体下沉</li>
+                            <li>动作过程中时时检点肩、肘、胸是否紧绷</li>
+                            <li>收功后自检：脚心是否发热、掌心是否微汗</li>
+                        </ul>
+                    </article>
+                    <article class="essence-card emphasis">
+                        <h3>贯通</h3>
+                        <p>从脚到手一条线，意念如水不断，动作如弧线连绵。贯通之后，力由内生，不借外力。</p>
+                        <ul class="essence-list">
+                            <li>每式起落都串联“脚-腿-腰-背-臂-掌”六点</li>
+                            <li>呼吸与动作一进一退，不脱节</li>
+                            <li>配合“内三合”：心与意合、意与气合、气与力合</li>
+                        </ul>
+                    </article>
+                    <article class="essence-card emphasis">
+                        <h3>回光</h3>
+                        <p>闭上眼睛看自身。每式结束，收回视线，察觉体内细微波动，让意念在身内巡行。</p>
+                        <ul class="essence-list">
+                            <li>练习中段加入片刻闭目，聆听心跳与呼吸</li>
+                            <li>每日练后以静坐五分钟回光返照</li>
+                            <li>记录气感变化，作为下一次调整依据</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="practice-section practice-routine" id="routine">
+            <div class="container">
+                <div class="section-header">
+                    <p class="section-eyebrow">日课安排</p>
+                    <h2 class="section-title">循序渐进的训练节奏</h2>
+                    <p class="section-subtitle">老练功者不争一朝一夕，坚持三阶段循环：打基础、进阶巩固、融合拓展。每阶段至少持续七日，期间随身记录体感。</p>
+                </div>
+                <div class="practice-stages">
+                    <article class="stage-card">
+                        <h3>基础日课</h3>
+                        <p>每日清晨 20 分钟，重在站桩与呼吸。</p>
+                        <ul>
+                            <li>5 分钟站桩：涌泉吸地，命门外撑</li>
+                            <li>八式各 6 遍，呼吸自然配合</li>
+                            <li>收功静站 3 分钟，记录体温、出汗与气感</li>
+                        </ul>
+                    </article>
+                    <article class="stage-card">
+                        <h3>进阶巩固</h3>
+                        <p>午后或傍晚 30 分钟，强化筋骨与意念。</p>
+                        <ul>
+                            <li>加入缓行步伐，配合式三、式五</li>
+                            <li>每式停留 3~5 息，细察松沉与力线</li>
+                            <li>记录身体某一部位的细微信号</li>
+                        </ul>
+                    </article>
+                    <article class="stage-card">
+                        <h3>融合拓展</h3>
+                        <p>每周两次，延伸至 45 分钟，结合静坐与吐纳。</p>
+                        <ul>
+                            <li>开场 10 分钟逆腹式呼吸</li>
+                            <li>八式后加 5 分钟静坐回观</li>
+                            <li>结合轻柔拍打，疏理十二经络</li>
+                        </ul>
+                    </article>
+                </div>
+                <div class="practice-tip">
+                    <i class="fas fa-lightbulb"></i>
+                    <p>若遇气机堵滞，勿强求进度。暂缓复杂动作，回到站桩与式一、式八的呼吸调匀，再行推进。</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="practice-section practice-alignment">
+            <div class="container">
+                <div class="section-header">
+                    <p class="section-eyebrow">自我校准</p>
+                    <h2 class="section-title">检点身体与心意的刻度</h2>
+                    <p class="section-subtitle">功夫在日常检点。用清晰的校准清单与体察记录，让练功从模糊走向精准。</p>
+                </div>
+                <div class="alignment-grid">
+                    <article class="alignment-card">
+                        <h3>身体对线检查</h3>
+                        <ul class="checklist">
+                            <li><i class="fas fa-check-circle"></i> 站桩时耳、肩、胯、踝四点是否成线</li>
+                            <li><i class="fas fa-check-circle"></i> 膝盖有无内扣外展，脚掌三点是否均匀</li>
+                            <li><i class="fas fa-check-circle"></i> 脊柱是否中正，尾闾是否内收不上翘</li>
+                            <li><i class="fas fa-check-circle"></i> 推掌时肩胛有无贴背，肘窝朝向是否正</li>
+                        </ul>
+                    </article>
+                    <article class="alignment-card">
+                        <h3>呼吸与心意记录</h3>
+                        <ul class="checklist">
+                            <li><i class="fas fa-check-circle"></i> 呼吸是否绵长、均匀且无声</li>
+                            <li><i class="fas fa-check-circle"></i> 意守丹田能否保持不散</li>
+                            <li><i class="fas fa-check-circle"></i> 练后四肢末端是否有温热或微麻感</li>
+                            <li><i class="fas fa-check-circle"></i> 心绪是否平稳，若浮躁立刻放慢节奏</li>
+                        </ul>
+                    </article>
+                </div>
+                <div class="insight-quote">
+                    <i class="fas fa-quote-left"></i>
+                    <p>“功到深处不在招式快慢，而在意念是否紧贴呼吸，呼吸能否带动气血，气血能否润泽筋骨。” —— 老练功者口授</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="practice-section practice-journal">
+            <div class="container">
+                <div class="section-header">
+                    <p class="section-eyebrow">精修札记</p>
+                    <h2 class="section-title">二十年实修带来的提醒</h2>
+                    <p class="section-subtitle">八部金刚功练至深处，心态、呼吸、身体都要慢慢磨。以下笔记摘自多年实修记录，供同道参考。</p>
+                </div>
+                <div class="journal-grid">
+                    <article class="journal-entry">
+                        <h3>身先行，意随后</h3>
+                        <p>初学时只顾意念，身体却僵硬。十年后才明白：先让身体走出正确轨迹，再让意念贴着身体微调。动作圆了，气自然能走全身。</p>
+                        <ul>
+                            <li>先按外形标准练足三月，再谈“意守”</li>
+                            <li>每周一次镜前练习，检视身形偏差</li>
+                            <li>意念不离丹田，切勿上浮至胸头</li>
+                        </ul>
+                    </article>
+                    <article class="journal-entry">
+                        <h3>慢就是快</h3>
+                        <p>每式至少十息，从容转换。越想快，越发空；慢下来，气血才能跟上动作，丹田才会有热度。</p>
+                        <ul>
+                            <li>呼吸不追求深，大象无形、细水长流</li>
+                            <li>闷热季节以吐纳为先，动作适度减量</li>
+                            <li>每练一阶段必有倦怠，守住底线不放弃</li>
+                        </ul>
+                    </article>
+                    <article class="journal-entry">
+                        <h3>护养与修复</h3>
+                        <p>功夫要护身，不可伤身。练后必做舒筋，饮温水一杯，睡前以掌心覆丹田三分钟，温养内气。</p>
+                        <ul>
+                            <li>出现关节酸胀，回到站桩与式八调和</li>
+                            <li>按揉足三里、太溪，疏导气机</li>
+                            <li>坚持记录睡眠与脉搏变化</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="practice-section practice-callout">
+            <div class="container">
+                <div class="callout-card">
+                    <h2>功在日久，贵在恒心</h2>
+                    <p>八部金刚功不是一套炫目的拳架，而是养护筋骨、充盈正气的终身功课。以本页为蓝图，结合自身体质调整节奏，日积月累，金刚之体自会成就。</p>
+                    <a href="index.html#about" class="btn btn-primary">了解调理方案</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <p>© 2024 传统中医诊所 | 传承经典，守护健康</p>
+                <div class="footer-links">
+                    <a href="index.html#about">关于我们</a>
+                    <a href="index.html#shennong">神农本草</a>
+                    <a href="babu-jingang-gong.html">八部金刚功</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
                 <li class="nav-item"><a href="#books" class="nav-link">好书推荐</a></li>
                 <li class="nav-item"><a href="#about" class="nav-link">关于我们</a></li>
                 <li class="nav-item"><a href="zhongyao.html" class="nav-link">神农本草</a></li>
+                <li class="nav-item"><a href="babu-jingang-gong.html" class="nav-link">八部金刚功</a></li>
             </ul>
             <div class="nav-actions">
                 <button class="bookmark-btn" id="bookmarkBtn" title="收藏页面">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -42,4 +42,10 @@
         <changefreq>weekly</changefreq>
         <priority>0.9</priority>
     </url>
+    <url>
+        <loc>https://traditionalchinesemedicine.online/babu-jingang-gong.html</loc>
+        <lastmod>2024-01-15</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.7</priority>
+    </url>
 </urlset>

--- a/styles.css
+++ b/styles.css
@@ -1748,3 +1748,483 @@ body {
         padding: 1.8rem 1.5rem;
     }
 }
+
+/* 八部金刚功页面 */
+.practice-hero {
+    position: relative;
+    margin-top: 80px;
+    padding: 180px 0 140px;
+    background: linear-gradient(rgba(18, 32, 28, 0.75), rgba(18, 32, 28, 0.6)),
+        url('https://images.unsplash.com/photo-1517837016564-bfc120f0f167?auto=format&fit=crop&w=1600&q=80');
+    background-size: cover;
+    background-position: center;
+    color: #ffffff;
+}
+
+.practice-hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(67, 160, 71, 0.65), rgba(21, 101, 192, 0.45));
+}
+
+.practice-hero .container {
+    position: relative;
+    z-index: 1;
+}
+
+.practice-hero-content {
+    max-width: 840px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.practice-hero-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.4rem 1.4rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.18);
+    backdrop-filter: blur(6px);
+    font-size: 0.95rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 1.5rem;
+}
+
+.practice-hero-title {
+    font-size: 3.2rem;
+    font-weight: 900;
+    margin-bottom: 1.5rem;
+    letter-spacing: 0.04em;
+}
+
+.practice-hero-subtitle {
+    font-size: 1.2rem;
+    line-height: 1.9;
+    margin-bottom: 2rem;
+    color: rgba(255, 255, 255, 0.92);
+}
+
+.practice-hero-points {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem 2rem;
+    justify-content: center;
+    margin-bottom: 2.5rem;
+    padding: 0;
+}
+
+.practice-hero-points li {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 1rem;
+}
+
+.practice-hero-points i {
+    color: #ffeb3b;
+    font-size: 1.1rem;
+}
+
+.practice-hero-actions {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.practice-section {
+    padding: 100px 0;
+    background: #ffffff;
+}
+
+.practice-section:nth-of-type(even) {
+    background: #f4f7f5;
+}
+
+.practice-section .section-header {
+    margin-bottom: 3rem;
+}
+
+.essence-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 2rem;
+}
+
+.essence-card {
+    background: #ffffff;
+    padding: 2.2rem;
+    border-radius: 18px;
+    border: 1px solid rgba(76, 175, 80, 0.12);
+    box-shadow: 0 20px 45px rgba(15, 68, 48, 0.08);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.essence-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 30px 60px rgba(15, 68, 48, 0.12);
+}
+
+.essence-card h3 {
+    font-size: 1.6rem;
+    color: #1b4332;
+    margin-bottom: 1rem;
+}
+
+.essence-card p {
+    color: #4f5b48;
+    margin-bottom: 1.2rem;
+    line-height: 1.8;
+}
+
+.essence-card.emphasis {
+    background: linear-gradient(145deg, rgba(76, 175, 80, 0.12), rgba(76, 175, 80, 0.04));
+    border-color: rgba(76, 175, 80, 0.25);
+}
+
+.essence-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.6rem;
+}
+
+.essence-list li {
+    position: relative;
+    padding-left: 1.4rem;
+    color: #455a47;
+}
+
+.essence-list li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.55rem;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #4CAF50, #45a049);
+}
+
+.practice-movements .section-subtitle {
+    max-width: 780px;
+}
+
+.movement-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 2rem;
+}
+
+.movement-card {
+    background: #ffffff;
+    border-radius: 18px;
+    border: 1px solid rgba(33, 150, 83, 0.15);
+    padding: 2rem;
+    box-shadow: 0 15px 40px rgba(13, 71, 29, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
+}
+
+.movement-card h3 {
+    font-size: 1.4rem;
+    color: #1b4332;
+}
+
+.movement-card p {
+    color: #546a59;
+    line-height: 1.7;
+}
+
+.movement-focus {
+    font-weight: 600;
+    color: #2e7d32;
+    background: rgba(76, 175, 80, 0.12);
+    padding: 0.6rem 1rem;
+    border-radius: 12px;
+}
+
+.movement-card ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.5rem;
+}
+
+.movement-card li {
+    position: relative;
+    padding-left: 1.3rem;
+    color: #455a47;
+}
+
+.movement-card li::before {
+    content: "➤";
+    position: absolute;
+    left: 0;
+    top: 0.1rem;
+    color: #4CAF50;
+    font-size: 0.9rem;
+}
+
+.practice-stages {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 2rem;
+}
+
+.stage-card {
+    background: #ffffff;
+    border-radius: 18px;
+    border: 1px solid rgba(76, 175, 80, 0.18);
+    padding: 2.2rem;
+    box-shadow: 0 15px 35px rgba(15, 68, 48, 0.08);
+}
+
+.stage-card h3 {
+    font-size: 1.45rem;
+    margin-bottom: 1rem;
+    color: #1b4332;
+}
+
+.stage-card p {
+    color: #4f5b48;
+    margin-bottom: 1.1rem;
+    line-height: 1.7;
+}
+
+.stage-card ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.6rem;
+}
+
+.stage-card li {
+    position: relative;
+    padding-left: 1.4rem;
+    color: #455a47;
+}
+
+.stage-card li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.45rem;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: rgba(76, 175, 80, 0.6);
+}
+
+.practice-tip {
+    margin-top: 2.5rem;
+    padding: 1.6rem 2rem;
+    border-radius: 16px;
+    background: rgba(76, 175, 80, 0.1);
+    color: #2e7d32;
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.practice-tip i {
+    font-size: 1.5rem;
+}
+
+.alignment-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+}
+
+.alignment-card {
+    background: #ffffff;
+    border-radius: 18px;
+    border: 1px solid rgba(76, 175, 80, 0.18);
+    padding: 2.2rem;
+    box-shadow: 0 18px 35px rgba(15, 68, 48, 0.08);
+}
+
+.alignment-card h3 {
+    font-size: 1.4rem;
+    margin-bottom: 1rem;
+    color: #1b4332;
+}
+
+.checklist {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.7rem;
+}
+
+.checklist li {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.6rem;
+    color: #455a47;
+    line-height: 1.6;
+}
+
+.checklist i {
+    color: #4CAF50;
+    margin-top: 0.2rem;
+}
+
+.insight-quote {
+    margin-top: 3rem;
+    padding: 2.2rem;
+    border-radius: 18px;
+    background: linear-gradient(135deg, rgba(67, 160, 71, 0.12), rgba(21, 101, 192, 0.08));
+    color: #1b4332;
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    font-style: italic;
+}
+
+.insight-quote i {
+    font-size: 2rem;
+    color: #2e7d32;
+}
+
+.journal-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 2rem;
+}
+
+.journal-entry {
+    background: #ffffff;
+    border-radius: 18px;
+    border: 1px solid rgba(76, 175, 80, 0.18);
+    padding: 2.2rem;
+    box-shadow: 0 20px 40px rgba(15, 68, 48, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.journal-entry h3 {
+    font-size: 1.45rem;
+    color: #1b4332;
+}
+
+.journal-entry p {
+    color: #4f5b48;
+    line-height: 1.8;
+}
+
+.journal-entry ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.6rem;
+}
+
+.journal-entry li {
+    position: relative;
+    padding-left: 1.3rem;
+    color: #455a47;
+}
+
+.journal-entry li::before {
+    content: "•";
+    position: absolute;
+    left: 0;
+    top: 0;
+    color: #4CAF50;
+    font-size: 1.1rem;
+}
+
+.practice-callout {
+    background: linear-gradient(135deg, #f1f8e9 0%, #ffffff 100%);
+}
+
+.callout-card {
+    max-width: 780px;
+    margin: 0 auto;
+    text-align: center;
+    padding: 3rem;
+    border-radius: 24px;
+    background: #ffffff;
+    border: 1px solid rgba(76, 175, 80, 0.15);
+    box-shadow: 0 25px 55px rgba(15, 68, 48, 0.1);
+}
+
+.callout-card h2 {
+    font-size: 2.2rem;
+    margin-bottom: 1.2rem;
+    color: #1b4332;
+}
+
+.callout-card p {
+    color: #4f5b48;
+    margin-bottom: 2rem;
+    line-height: 1.8;
+}
+
+@media (max-width: 992px) {
+    .practice-hero {
+        padding: 160px 0 120px;
+    }
+
+    .practice-hero-title {
+        font-size: 2.6rem;
+    }
+
+    .practice-hero-points {
+        justify-content: flex-start;
+    }
+}
+
+@media (max-width: 768px) {
+    .practice-hero {
+        padding: 140px 0 100px;
+    }
+
+    .practice-hero-title {
+        font-size: 2.3rem;
+    }
+
+    .practice-hero-subtitle {
+        font-size: 1.05rem;
+    }
+
+    .practice-hero-points {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .practice-section {
+        padding: 80px 0;
+    }
+
+    .callout-card {
+        padding: 2.2rem 1.8rem;
+    }
+}
+
+@media (max-width: 576px) {
+    .practice-hero {
+        padding: 120px 0 80px;
+    }
+
+    .practice-hero-points li {
+        font-size: 0.95rem;
+    }
+
+    .practice-hero-actions {
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated 八部金刚功页面 with实战心得、八式拆解、日课安排和自我校准清单，展现老练功者的修炼经验
- extend全站样式以支持八部金刚功页面的英雄横幅、要点卡片、训练阶段、笔记等布局
- 更新首页导航与sitemap以链接新的金刚功内容页面

## Testing
- 未运行（项目未提供自动化测试）

------
https://chatgpt.com/codex/tasks/task_e_68d0d018cef08321bd18fb5fcb7a0f46