### PR TITLE
Remove images from homepage book recommendations

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,9 +175,6 @@
 
             <div class="books-grid">
                 <article class="book-card">
-                    <div class="book-media">
-                        <img src="https://images.unsplash.com/photo-1481627834876-b7833e8f5570?w=600&amp;h=800&amp;fit=crop&amp;crop=center" alt="黄帝内经" loading="lazy">
-                    </div>
                     <div class="book-info">
                         <h3 class="book-title">黄帝内经</h3>
                         <p class="book-meta">经络脏腑 · 理论总纲</p>
@@ -186,9 +183,6 @@
                 </article>
 
                 <article class="book-card">
-                    <div class="book-media">
-                        <img src="https://images.unsplash.com/photo-1543002588-bfa74002ed7e?w=600&amp;h=800&amp;fit=crop&amp;crop=center" alt="伤寒论" loading="lazy">
-                    </div>
                     <div class="book-info">
                         <h3 class="book-title">伤寒论</h3>
                         <p class="book-meta">六经辨证 · 经方典范</p>
@@ -197,9 +191,6 @@
                 </article>
 
                 <article class="book-card">
-                    <div class="book-media">
-                        <img src="https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=600&amp;h=800&amp;fit=crop&amp;crop=center" alt="金匮要略" loading="lazy">
-                    </div>
                     <div class="book-info">
                         <h3 class="book-title">金匮要略</h3>
                         <p class="book-meta">杂病纲领 · 经方拓展</p>
@@ -208,9 +199,6 @@
                 </article>
 
                 <article class="book-card">
-                    <div class="book-media">
-                        <img src="https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?w=600&amp;h=800&amp;fit=crop&amp;crop=center" alt="神农本草经" loading="lazy">
-                    </div>
                     <div class="book-info">
                         <h3 class="book-title">神农本草经</h3>
                         <p class="book-meta">上中下品 · 药性原典</p>


### PR DESCRIPTION
## Summary
- remove cover images from the homepage book recommendation cards so only textual details are shown

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68da3369c0408321873f04243c651101