### PR TITLE
Update homepage branding from 传统中医诊所 to 传统中医传承

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     {
         "@context": "https://schema.org",
         "@type": "MedicalClinic",
-        "name": "传统中医诊所",
+        "name": "传统中医传承",
         "alternateName": "中医诊所",
         "description": "提供专业中医治疗、经方治病、中医咨询",
         "url": "https://traditionalchinesemedicine.online",
@@ -71,7 +71,7 @@
         <div class="nav-container">
             <div class="nav-logo">
                 <i class="fas fa-leaf"></i>
-                <span>传统中医诊所</span>
+                <span>传统中医传承</span>
             </div>
             <ul class="nav-menu">
                 <li class="nav-item"><a href="#home" class="nav-link">首页</a></li>
@@ -334,7 +334,7 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-section">
-                    <h3>传统中医诊所</h3>
+                    <h3>传统中医传承</h3>
                     <p>传承中医精髓，专业中医师坐诊，为您的健康保驾护航</p>
                     <div class="social-links">
                         <a href="#" title="微信：zhangyouxun2013"><i class="fab fa-weixin"></i></a>
@@ -368,7 +368,7 @@
             </div>
 
             <div class="footer-bottom">
-                <p>&copy; 2024 传统中医诊所. 保留所有权利. | 经方传承 · 经方治病 · 专业中医咨询</p>
+                <p>&copy; 2024 传统中医传承. 保留所有权利. | 经方传承 · 经方治病 · 专业中医咨询</p>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
## Summary
- rename the homepage branding text from “传统中医诊所” to “传统中医传承” across the structured data, header logo, and footer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da352fcdf08321b179a629acc7264d