### PR TITLE
Add nutrition highlight to homepage Shennong section

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,6 +127,36 @@
                 <p class="section-subtitle">精选《神农本草经》中耳熟能详的本草要药，系统梳理性味主治，12味起分页呈现，阅读更轻松。</p>
             </div>
 
+            <section class="food-nutrition-highlight" aria-label="常见美食营养信息">
+                <header class="highlight-header">
+                    <span class="highlight-eyebrow">食疗灵感</span>
+                    <h3 class="highlight-title">常见美食营养速览</h3>
+                    <p class="highlight-description">在日常饮食中融入谷物、豆类与果蔬的力量，既能汲取现代营养学所强调的膳食纤维、优质蛋白，也能贴合中医“药食同源”的调养理念。</p>
+                </header>
+                <div class="highlight-grid">
+                    <article class="highlight-card">
+                        <h4 class="highlight-food">燕麦粥</h4>
+                        <p class="highlight-nutrients">膳食纤维 3.5g · 植物蛋白 5.9g · 富含β-葡聚糖</p>
+                        <p class="highlight-note">润燥养胃、帮助稳定餐后血糖，适合搭配红枣、枸杞补益气血，早起温服助力肠道顺畅。</p>
+                    </article>
+                    <article class="highlight-card">
+                        <h4 class="highlight-food">山药薏米粥</h4>
+                        <p class="highlight-nutrients">优质碳水 · 蛋白质 4.1g · 钾与维生素B族</p>
+                        <p class="highlight-note">山药健脾补气，薏米利湿健脾，二者同煮兼顾能量与祛湿需求，体虚乏力或湿气重人群可常食。</p>
+                    </article>
+                    <article class="highlight-card">
+                        <h4 class="highlight-food">银耳莲子羹</h4>
+                        <p class="highlight-nutrients">胶质多糖 · 膳食纤维 · 植物钙与钾</p>
+                        <p class="highlight-note">银耳润肺生津、莲子养心安神，搭配枸杞可补肝肾，夜间作甜品既滋补又不易上火。</p>
+                    </article>
+                    <article class="highlight-card">
+                        <h4 class="highlight-food">黑芝麻糊</h4>
+                        <p class="highlight-nutrients">不饱和脂肪酸 · 钙 780mg · 维生素E</p>
+                        <p class="highlight-note">黑芝麻补肝肾、养发润燥，与核桃粉同冲泡可以增强记忆力与骨骼营养，适合青少年与老年人。</p>
+                    </article>
+                </div>
+            </section>
+
             <div class="herb-toolbar">
                 <div class="herb-search">
                     <label for="homepageHerbSearch"><i class="fas fa-search"></i><span>快速查找本草</span></label>

--- a/styles.css
+++ b/styles.css
@@ -759,6 +759,84 @@ body {
     color: #4f5b48;
 }
 
+.food-nutrition-highlight {
+    margin: 2.5rem 0 3rem;
+    padding: 2.5rem;
+    background: linear-gradient(135deg, rgba(76, 175, 80, 0.08), rgba(76, 175, 80, 0.02));
+    border-radius: 24px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.04);
+}
+
+.highlight-header {
+    max-width: 720px;
+    margin-bottom: 2rem;
+}
+
+.highlight-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 14px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #2e7d32;
+    background-color: rgba(76, 175, 80, 0.12);
+    border-radius: 999px;
+    letter-spacing: 2px;
+}
+
+.highlight-title {
+    font-size: 2rem;
+    margin: 1rem 0 0.75rem;
+    color: #1b5e20;
+}
+
+.highlight-description {
+    font-size: 1.05rem;
+    color: #4f5b62;
+    line-height: 1.8;
+}
+
+.highlight-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.highlight-card {
+    background-color: white;
+    border-radius: 18px;
+    padding: 1.5rem;
+    box-shadow: 0 10px 25px rgba(76, 175, 80, 0.12);
+    border: 1px solid rgba(76, 175, 80, 0.15);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.highlight-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 18px 32px rgba(76, 175, 80, 0.18);
+}
+
+.highlight-food {
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: #2e7d32;
+    margin-bottom: 0.75rem;
+}
+
+.highlight-nutrients {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #1b5e20;
+    margin-bottom: 0.85rem;
+}
+
+.highlight-note {
+    font-size: 0.95rem;
+    color: #546e7a;
+    line-height: 1.7;
+}
+
 .herb-toolbar {
     display: flex;
     align-items: center;
@@ -1005,6 +1083,15 @@ body {
 
     .shennong-section .section-title {
         font-size: 2.2rem;
+    }
+
+    .food-nutrition-highlight {
+        padding: 1.75rem;
+        margin: 2rem 0 2.5rem;
+    }
+
+    .highlight-grid {
+        grid-template-columns: 1fr;
     }
 
     .herb-toolbar {


### PR DESCRIPTION
## Summary
- introduce a food nutrition highlight block above the homepage Shennong herb list with concise nutrition notes for common dishes
- style the new highlight section with responsive cards that match the existing design language

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68de8805976c8321b5b0522af2b166b5