### PR TITLE
將傳統中醫網站改為繁體中文版本

### DIFF
--- a/POSTAL_CODES_README.md
+++ b/POSTAL_CODES_README.md
@@ -1,42 +1,42 @@
-# Postal Codes & Area Codes Directory
+# 郵遞區號與國際區碼查詢平台
 
-## 🌍 Overview
+## 🌍 概覽
 
-A comprehensive web application for looking up postal codes and telephone area codes worldwide. Built with modern web technologies and optimized for both desktop and mobile devices.
+這是一個可查詢全球郵遞區號與電話區碼的網頁應用，以現代前端技術打造，兼顧桌機與行動裝置的使用體驗。
 
-## ✨ Features
+## ✨ 特色功能
 
-### 🔍 Search Functionality
-- **Multi-tab Search**: Search by postal codes, area codes, or country codes
-- **Flexible Search**: Support for city, state, province, or country names
-- **Exact Match Option**: Toggle between exact and partial matching
-- **Real-time Results**: Instant search results with loading animations
+### 🔍 查詢機制
+- **多分頁搜尋**：可依郵遞區號、電話區碼或國碼切換查詢。
+- **關鍵字彈性**：支援城市、州、省或國家名稱等多元輸入。
+- **精確比對選項**：可切換完全符合或模糊搜尋。
+- **即時結果**：輸入後立即顯示結果，並具載入動畫。
 
-### 📊 Data Display
-- **Comprehensive Results**: Country, city, state/province, postal code, area code, and timezone
-- **Country Flags**: Visual country identification using flag icons
-- **Responsive Table**: Mobile-friendly results display
-- **Export Functionality**: Download results as CSV file
+### 📊 資料呈現
+- **資訊完整**：顯示國家、城市、州／省、郵遞區號、電話區碼與時區。
+- **國旗圖示**：以旗幟辨識國別。
+- **響應式表格**：行動裝置也能清晰閱讀。
+- **匯出功能**：支援下載 CSV 報表。
 
-### 🎨 User Experience
-- **Modern Design**: Clean, professional interface with gradient backgrounds
-- **Responsive Layout**: Optimized for all screen sizes
-- **Interactive Elements**: Hover effects and smooth animations
-- **Loading States**: Professional loading indicators
+### 🎨 使用體驗
+- **現代設計**：乾淨專業的漸層介面。
+- **自適應版面**：針對各種螢幕尺寸最佳化。
+- **互動效果**：滑鼠懸停與平滑動畫。
+- **載入提示**：提供明確的載入狀態。
 
-### 📱 Mobile Optimization
-- **Touch-Friendly**: Optimized for mobile devices
-- **Responsive Tables**: Adaptive table layouts for small screens
-- **Fast Loading**: Optimized performance for mobile networks
+### 📱 行動優化
+- **觸控友善**：行動操作順暢。
+- **可調式表格**：小螢幕自動調整欄位。
+- **快速載入**：針對行動網路最佳化效能。
 
-## 🛠️ Technical Implementation
+## 🛠️ 技術實作
 
-### Frontend Technologies
-- **HTML5**: Semantic markup structure
-- **CSS3**: Modern styling with Flexbox and Grid
-- **JavaScript (ES6+)**: Interactive functionality
-- **Font Awesome**: Icon library
-- **Google Fonts**: Inter font family
+### 前端技術
+- **HTML5**：語意化標記結構。
+- **CSS3**：運用 Flexbox 與 Grid 的現代化樣式。
+- **JavaScript (ES6+)**：負責互動邏輯。
+- **Font Awesome**：圖示資源。
+- **Google Fonts**：Inter 字體家族。
 
 ### SEO Optimization
 - **Meta Tags**: Comprehensive SEO meta tags
@@ -79,65 +79,65 @@ The application includes sample data for major cities worldwide:
 - **Case Insensitive**: Search works regardless of case
 - **Multiple Fields**: Searches across all data fields
 
-### Export Functionality
-- **CSV Export**: Download search results as CSV file
-- **Complete Data**: Includes all fields in export
-- **Formatted Output**: Properly formatted for spreadsheet applications
+### 匯出功能
+- **CSV 匯出**：可將查詢結果下載為 CSV 檔。
+- **資料完整**：匯出內容包含所有欄位。
+- **格式友善**：適用於試算表程式。
 
-## 📱 Mobile Experience
+## 📱 行動體驗
 
-### Responsive Design
-- **Adaptive Layout**: Automatically adjusts to screen size
-- **Touch Optimization**: Large touch targets for mobile
-- **Fast Performance**: Optimized for mobile networks
-- **Offline Support**: Service Worker caching
+### 響應式設計
+- **自適應版面**：依螢幕尺寸自動調整。
+- **觸控優化**：大型按鈕方便手機操作。
+- **高速效能**：針對行動網路調整載入速度。
+- **離線支援**：Service Worker 快取機制。
 
-### Mobile Features
-- **Swipe Navigation**: Touch-friendly interface
-- **Optimized Tables**: Mobile-friendly table display
-- **Quick Search**: Streamlined search experience
-- **Export Support**: Mobile-compatible export functionality
+### 行動特色
+- **滑動操作**：介面支援手勢切換。
+- **表格最佳化**：行動版呈現易於閱讀。
+- **快速搜尋**：提供精簡搜尋流程。
+- **匯出支援**：行動裝置亦可匯出資料。
 
-## 🔧 Customization
+## 🔧 自訂調整
 
-### Adding New Data
+### 新增資料
 ```javascript
 const newData = {
-    country: 'Country Name',
-    city: 'City Name',
-    state: 'State/Province',
-    postal: 'Postal Code Range',
-    area: 'Area Code',
-    timezone: 'Timezone'
+    country: '國家名稱',
+    city: '城市名稱',
+    state: '州／省',
+    postal: '郵遞區號範圍',
+    area: '電話區碼',
+    timezone: '時區'
 };
 ```
 
-### Styling Customization
-- **Color Scheme**: Modify CSS variables for branding
-- **Layout**: Adjust grid and flexbox properties
-- **Typography**: Customize font families and sizes
-- **Animations**: Modify transition and animation properties
+### 介面調整
+- **配色**：調整 CSS 變數以符合品牌。
+- **版面**：修改 Grid 與 Flexbox 設定。
+- **字體**：自訂字型與大小。
+- **動畫**：調整轉場與動畫參數。
 
-## 📈 Performance Metrics
+## 📈 效能指標
 
-### Loading Speed
-- **First Contentful Paint**: < 1.5s
-- **Largest Contentful Paint**: < 2.5s
-- **Cumulative Layout Shift**: < 0.1
-- **First Input Delay**: < 100ms
+### 載入速度
+- **首次內容繪製**：小於 1.5 秒。
+- **最大內容繪製**：小於 2.5 秒。
+- **累積版面偏移**：低於 0.1。
+- **首次輸入延遲**：低於 100 毫秒。
 
-### SEO Score
-- **PageSpeed Insights**: 90+ (Mobile & Desktop)
-- **Core Web Vitals**: All metrics in green
-- **Accessibility**: WCAG 2.1 AA compliant
-- **Best Practices**: 100% score
+### SEO 與可及性
+- **PageSpeed Insights**：行動與桌機皆達 90 分以上。
+- **核心網路指標**：全部維持綠色標準。
+- **無障礙**：符合 WCAG 2.1 AA 等級。
+- **最佳實務**：達成 100% 評分。
 
-## 🔗 Integration
+## 🔗 整合指引
 
-### Navigation Integration
-- **Main Site**: Integrated into primary navigation
-- **Footer Links**: Added to site footer
-- **Sitemap**: Included in XML sitemap
+### 導覽整合
+- **主選單**：可納入網站導覽列。
+- **頁尾連結**：於頁尾提供快速進入。
+- **網站地圖**：可加入 XML sitemap 便於索引。
 - **Service Worker**: Cached for offline access
 
 ### SEO Integration

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Heritage TCM Website
+# 承古堂網站說明
 
-An English-language refresh of the TraditionalChineseMedicine.online project. The site highlights classical formulas, trusted practitioners, movement practices, and nutrition ideas in a modern layout.
+本專案為 TraditionalChineseMedicine.online 的繁體中文版本，內容涵蓋經典方藥、名醫紀事、導引功法與食療養生，版面以現代視覺呈現。
 
-## Key pages
-- **index.html** – Landing page with herbal spotlights, recommended reading, and FAQs.
-- **famous-tcm-doctors.html** – Profiles of influential TCM physicians with links to detailed biographies.
-- **ba-duan-jin.html** – English guide to the Eight Brocades qigong sequence with video recommendations.
-- **babu-jingang-gong.html** – Advanced practice notes for Ba Bu Jingang Gong.
-- **ni-haixia.html** – Tribute page to Dr. Ni Hai-Xia and his teaching legacy.
-- **food-nutrition.html** – TCM-inspired meal planning tips and seasonal guidance.
-- **zhongyao.html** – Materia medica highlights (see the homepage herb search for quick access).
+## 主要頁面
+- **index.html**：首頁，集結本草精選、經典書單與常見問題。
+- **famous-tcm-doctors.html**：歷代名醫概覽，可進入各人物詳細傳記。
+- **ba-duan-jin.html**：八段錦氣功教學與影音推薦。
+- **babu-jingang-gong.html**：八部金剛功進階訓練筆記。
+- **ni-haixia.html**：倪海廈醫師專頁，介紹生平與研習資源。
+- **food-nutrition.html**：中醫飲食規畫與四時食養建議。
+- **zhongyao.html**：神農本草精要，可快速搜尋藥性與等級。
 
-## Development notes
-- All copy has been rewritten in English to suit an international audience.
-- Herbal data for the homepage lives in `data/shennong-herbs.js` and currently covers 24 herbs spanning the superior, medium, and regular classes. Add new entries to extend it further.
-- Global interactions (navigation, FAQ toggles, smooth scrolling) are handled in `script.js`.
+## 開發備註
+- 文字內容全面改寫為繁體中文，以貼近華語讀者。
+- 首頁本草資料來源於 `data/shennong-herbs.js`，目前收錄 24 味藥材，可依需求擴增。
+- 導航、常見問題展開與平滑捲動等互動功能集中於 `script.js`。
 
-To explore locally, open `index.html` in your browser and follow the navigation links. No build step is required.
+開發者可直接在瀏覽器開啟 `index.html` 進行檢視，無需額外建置流程。

--- a/ba-duan-jin.html
+++ b/ba-duan-jin.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Eight Brocades Qigong Guide | Heritage TCM</title>
-    <meta name="description" content="Step-by-step instructions, follow-along videos, and practice tips for Ba Duan Jin, the Eight Brocades qigong set.">
+    <title>八段錦氣功指南｜承古堂</title>
+    <meta name="description" content="提供八段錦逐式教學、影音帶練與練習心得，協助您調和身心。">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 </head>
@@ -13,20 +13,20 @@
         <div class="nav-container">
             <div class="nav-logo">
                 <i class="fas fa-leaf"></i>
-                <span>Heritage TCM</span>
+                <span>承古堂</span>
             </div>
             <ul class="nav-menu">
-                <li class="nav-item"><a href="index.html#home" class="nav-link">Home</a></li>
-                <li class="nav-item"><a href="index.html#books" class="nav-link">Reading List</a></li>
-                <li class="nav-item"><a href="index.html#about" class="nav-link">About</a></li>
-                <li class="nav-item"><a href="zhongyao.html" class="nav-link">Herbal Library</a></li>
-                <li class="nav-item"><a href="babu-jingang-gong.html" class="nav-link">Ba Duan Jin Plus</a></li>
-                <li class="nav-item"><a href="ba-duan-jin.html" class="nav-link active">Eight Brocades</a></li>
+                <li class="nav-item"><a href="index.html#home" class="nav-link">首頁</a></li>
+                <li class="nav-item"><a href="index.html#books" class="nav-link">經典書單</a></li>
+                <li class="nav-item"><a href="index.html#about" class="nav-link">關於我們</a></li>
+                <li class="nav-item"><a href="zhongyao.html" class="nav-link">本草庫</a></li>
+                <li class="nav-item"><a href="babu-jingang-gong.html" class="nav-link">八部金剛功</a></li>
+                <li class="nav-item"><a href="ba-duan-jin.html" class="nav-link active">八段錦</a></li>
             </ul>
             <div class="nav-actions">
-                <button class="bookmark-btn" id="bookmarkBtn" title="Bookmark this page">
+                <button class="bookmark-btn" id="bookmarkBtn" title="將本頁加入書籤">
                     <i class="fas fa-bookmark"></i>
-                    <span>Bookmark</span>
+                    <span>收藏</span>
                 </button>
             </div>
             <div class="hamburger">
@@ -41,17 +41,17 @@
         <section class="practice-hero baduanjin-hero">
             <div class="container">
                 <div class="practice-hero-content">
-                    <span class="practice-hero-eyebrow">Ten mindful minutes</span>
-                    <h1 class="practice-hero-title">Eight Brocades Qigong</h1>
-                    <p class="practice-hero-subtitle">This beloved qigong sequence balances posture, breath, and intention. Use it to awaken circulation, release shoulder and back tension, and cultivate calm focus during a busy day.</p>
+                    <span class="practice-hero-eyebrow">十分鐘的身心調息</span>
+                    <h1 class="practice-hero-title">八段錦氣功</h1>
+                    <p class="practice-hero-subtitle">經典功法調和身形、呼吸與意念，可喚醒氣血循環、舒解肩背緊繃，忙碌之餘重拾專注與平靜。</p>
                     <ul class="practice-hero-points">
-                        <li><i class="fas fa-wind"></i> Step-by-step explanations linking movement, breath, and visualization.</li>
-                        <li><i class="fas fa-video"></i> Curated follow-along videos with pacing cues and alignment tips.</li>
-                        <li><i class="fas fa-heartbeat"></i> Practice plans tailored for office workers, restorative evenings, and better sleep.</li>
+                        <li><i class="fas fa-wind"></i> 逐式解析動作、呼吸與意念的結合。</li>
+                        <li><i class="fas fa-video"></i> 精選影音帶練，標示節奏與身形要點。</li>
+                        <li><i class="fas fa-heartbeat"></i> 依上班族、晚間放鬆與睡前調息設計練習方案。</li>
                     </ul>
                     <div class="practice-hero-actions">
-                        <a href="#videos" class="btn btn-primary">Watch the routines</a>
-                        <a href="#articles" class="btn btn-secondary">Read the highlights</a>
+                        <a href="#videos" class="btn btn-primary">觀看帶練影片</a>
+                        <a href="#articles" class="btn btn-secondary">閱讀重點</a>
                     </div>
                 </div>
             </div>
@@ -60,25 +60,25 @@
         <section class="practice-section practice-videos" id="videos">
             <div class="container">
                 <div class="section-header">
-                    <p class="section-eyebrow">Follow along</p>
-                    <h2 class="section-title">Video library</h2>
-                    <p class="section-subtitle">Choose the pacing that fits your schedule—traditional rhythm, gentle stretching, or strength-focused variations.</p>
+                    <p class="section-eyebrow">跟著練習</p>
+                    <h2 class="section-title">影音教室</h2>
+                    <p class="section-subtitle">依照行程選擇節奏，可選傳統韻律、柔和伸展或強度變化版本。</p>
                 </div>
                 <div class="video-grid">
                     <article class="video-card">
-                        <iframe src="https://www.youtube.com/embed/rzQxC87Yw84" title="Eight Brocades Official Routine" loading="lazy" allowfullscreen></iframe>
-                        <h3>Official Health Qigong routine</h3>
-                        <span>7-minute practice · Clear verbal cues · Suitable for beginners</span>
+                        <iframe src="https://www.youtube.com/embed/rzQxC87Yw84" title="八段錦官方示範" loading="lazy" allowfullscreen></iframe>
+                        <h3>官方健康氣功版</h3>
+                        <span>7 分鐘練習｜口令清晰｜新手友善</span>
                     </article>
                     <article class="video-card">
-                        <iframe src="https://www.youtube.com/embed/JVix3B2c6pg" title="Eight Brocades for Office Workers" loading="lazy" allowfullscreen></iframe>
-                        <h3>Desk-friendly sequence</h3>
-                        <span>10-minute stretch · Emphasis on neck, shoulders, and wrists</span>
+                        <iframe src="https://www.youtube.com/embed/JVix3B2c6pg" title="八段錦辦公舒展版" loading="lazy" allowfullscreen></iframe>
+                        <h3>辦公舒展版</h3>
+                        <span>10 分鐘舒展｜重點放在頸肩與手腕</span>
                     </article>
                     <article class="video-card">
-                        <iframe src="https://www.youtube.com/embed/2oPptkPj2Ak" title="Evening Wind-down" loading="lazy" allowfullscreen></iframe>
-                        <h3>Evening wind-down</h3>
-                        <span>Slow pace · Guided breathing · Gentle hip and spine release</span>
+                        <iframe src="https://www.youtube.com/embed/2oPptkPj2Ak" title="八段錦夜間緩和版" loading="lazy" allowfullscreen></iframe>
+                        <h3>夜間緩和版</h3>
+                        <span>放慢節奏｜引導呼吸｜鬆開髖脊</span>
                     </article>
                 </div>
             </div>
@@ -87,73 +87,73 @@
         <section class="practice-section practice-breakdown" id="articles">
             <div class="container">
                 <div class="section-header">
-                    <p class="section-eyebrow">Movement glossary</p>
-                    <h2 class="section-title">Eight forms, eight intentions</h2>
-                    <p class="section-subtitle">Each posture has a classical name and a targeted effect. Use the notes below to fine-tune your form.</p>
+                    <p class="section-eyebrow">動作索引</p>
+                    <h2 class="section-title">八式八意</h2>
+                    <p class="section-subtitle">每式皆有古稱與功效，可依提示調整身形與意念。</p>
                 </div>
                 <div class="practice-grid">
                     <article>
-                        <h3>1. Two Hands Hold up the Heavens</h3>
-                        <p>Stretch from soles to fingertips as you inhale. Imagine the spine elongating while the shoulders melt away from the ears. Exhale to let palms float down.</p>
+                        <h3>一、雙手托天理三焦</h3>
+                        <p>吸氣時由腳掌延伸至指尖，想像脊柱拔長、肩膀鬆沉，呼氣讓雙掌緩緩下降。</p>
                         <ul>
-                            <li>Focus: lengthen the spine and open the ribcage.</li>
-                            <li>Tip: keep elbows soft; avoid locking the knees.</li>
+                            <li>重點：伸展脊柱，擴展胸廓。</li>
+                            <li>提示：手肘微彎，膝蓋勿僵直。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>2. Drawing the Bow to Shoot the Hawk</h3>
-                        <p>Shift weight to the right, extend the left arm as though nocking an arrow, then reverse. Breathe in as you open, out as you release.</p>
+                        <h3>二、左右開弓似射鵰</h3>
+                        <p>重心移向右側，左臂張弓，換側再作。張弓吸氣，放箭呼氣。</p>
                         <ul>
-                            <li>Focus: stimulate the lung and heart channels.</li>
-                            <li>Tip: keep hips level; let the gaze follow the imaginary arrow.</li>
+                            <li>重點：啟動心肺經絡。</li>
+                            <li>提示：骨盆保持水平，視線隨箭走。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>3. Separate Heaven and Earth</h3>
-                        <p>One hand lifts up while the other presses down. Alternate sides with gentle spirals through the torso.</p>
+                        <h3>三、調理脾胃須單舉</h3>
+                        <p>一手托天一手按地，交替左右，軀幹帶出柔和螺旋。</p>
                         <ul>
-                            <li>Focus: harmonise digestion and ease abdominal tension.</li>
-                            <li>Tip: imagine hands moving through water to keep resistance light.</li>
+                            <li>重點：調和脾胃、舒緩腹脹。</li>
+                            <li>提示：意守雙掌在水中滑行，動作輕柔。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>4. Wise Owl Gazes Backward</h3>
-                        <p>Turn the head slowly from side to side while maintaining a tall posture. Coordinate with steady breathing.</p>
+                        <h3>四、五勞七傷往後瞧</h3>
+                        <p>保持挺拔姿勢，緩慢左右回望，配合綿長呼吸。</p>
                         <ul>
-                            <li>Focus: release neck and shoulder tension.</li>
-                            <li>Tip: pivot from the upper back rather than wrenching the neck.</li>
+                            <li>重點：鬆開頸肩緊繃。</li>
+                            <li>提示：以上背帶動，而非硬扭頸項。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>5. Sway the Head and Shake the Tail</h3>
-                        <p>Shift into a wide stance, circle the torso, and sway the hips to disperse heat from the heart.</p>
+                        <h3>五、搖頭擺尾去心火</h3>
+                        <p>採馬步，軀幹畫圈、髖部擺動，引導心火下行。</p>
                         <ul>
-                            <li>Focus: soothe irritability and support digestion.</li>
-                            <li>Tip: keep movements smooth and circular, not jerky.</li>
+                            <li>重點：平和心情，助消化。</li>
+                            <li>提示：動作圓滑連貫，避免突兀。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>6. Two Hands Hold the Feet</h3>
-                        <p>Fold forward from the hips, sweeping the hands along the legs before rising. Coordinate the bend with a relaxed exhale.</p>
+                        <h3>六、兩手攀足固腎腰</h3>
+                        <p>由髖折疊前俯，雙手沿腿掃下再起，配合呼氣放鬆。</p>
                         <ul>
-                            <li>Focus: release the back line of the body; massage the kidneys.</li>
-                            <li>Tip: bend knees slightly if hamstrings feel tight.</li>
+                            <li>重點：舒展後側筋膜，溫養腎氣。</li>
+                            <li>提示：腿筋緊時微屈膝。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>7. Clench Fists with Fiery Eyes</h3>
-                        <p>Sink into a horse stance, punch forward with alternating fists, and emit a steady breath to release inner strength.</p>
+                        <h3>七、攢拳怒目增氣力</h3>
+                        <p>採馬步，雙拳交替推出，伴隨平穩吐氣，激發內勁。</p>
                         <ul>
-                            <li>Focus: strengthen legs and fortify protective qi.</li>
-                            <li>Tip: keep shoulders dropped and wrists aligned.</li>
+                            <li>重點：強健下肢，培護衛氣。</li>
+                            <li>提示：肩膀下沉，手腕與前臂成一直線。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>8. Bounce on the Heels to Prevent Illness</h3>
-                        <p>Rise onto the balls of the feet and gently drop the heels, sending soft vibrations through the body.</p>
+                        <h3>八、背後七顛百病消</h3>
+                        <p>踮起腳尖再輕落腳跟，讓柔和震動遍佈全身。</p>
                         <ul>
-                            <li>Focus: stimulate lymphatic flow and awaken the kidney channel.</li>
-                            <li>Tip: land softly; imagine waves rippling through the fascia.</li>
+                            <li>重點：活絡淋巴，喚醒腎經。</li>
+                            <li>提示：腳跟落地要輕，意念如波紋傳散。</li>
                         </ul>
                     </article>
                 </div>
@@ -163,36 +163,36 @@
         <section class="practice-section practice-faq" id="faq">
             <div class="container">
                 <div class="section-header">
-                    <p class="section-eyebrow">Practice wisdom</p>
-                    <h2 class="section-title">Frequently asked questions</h2>
-                    <p class="section-subtitle">Clear guidance to help you build a steady, enjoyable routine.</p>
+                    <p class="section-eyebrow">練功心得</p>
+                    <h2 class="section-title">常見提問</h2>
+                    <p class="section-subtitle">掌握節奏與重點，讓八段錦成為愉悅的日常練習。</p>
                 </div>
                 <div class="faq-content">
                     <div class="faq-item">
                         <div class="faq-question">
-                            <h3>How often should I practise the Eight Brocades?</h3>
+                            <h3>八段錦多久練一次最好？</h3>
                             <i class="fas fa-chevron-down"></i>
                         </div>
                         <div class="faq-answer">
-                            <p>Five to six sessions per week build momentum quickly. Even three shorter sessions keep the body open and responsive—consistency matters more than intensity.</p>
+                            <p>每週五至六次能快速建立身體記憶；即使一週三次、時間較短，只要持之以恆，身體依然會柔軟開展。</p>
                         </div>
                     </div>
                     <div class="faq-item">
                         <div class="faq-question">
-                            <h3>Can I combine Eight Brocades with strength or cardio training?</h3>
+                            <h3>能與重訓或有氧運動搭配嗎？</h3>
                             <i class="fas fa-chevron-down"></i>
                         </div>
                         <div class="faq-answer">
-                            <p>Absolutely. Practise Ba Duan Jin first to warm the joints, then move into strength or cardio work. Alternatively, use it as a cool-down to transition into rest.</p>
+                            <p>可以。可先練八段錦暖關節，再進入重訓或有氧；或於運動後作為收操，平順帶入休息。</p>
                         </div>
                     </div>
                     <div class="faq-item">
                         <div class="faq-question">
-                            <h3>What should I focus on if I’m practising at night?</h3>
+                            <h3>晚上練習要注意什麼？</h3>
                             <i class="fas fa-chevron-down"></i>
                         </div>
                         <div class="faq-answer">
-                            <p>Slow down the tempo, lengthen the exhalations, and emphasise postures three through six. Finish with a gentle seated meditation to anchor the calm.</p>
+                            <p>放慢節奏、延長吐氣，著重第三至第六式。最後可靜坐數分鐘，將寧靜沉澱於心。</p>
                         </div>
                     </div>
                 </div>
@@ -204,19 +204,19 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-section">
-                    <h3>Heritage TCM</h3>
-                    <p>Classical medicine for modern rhythms.</p>
+                    <h3>承古堂</h3>
+                    <p>以經方智慧對應現代生活節奏。</p>
                 </div>
                 <div class="footer-section">
-                    <h4>Quick Links</h4>
+                    <h4>快速連結</h4>
                     <ul>
-                        <li><a href="index.html#home">Home</a></li>
-                        <li><a href="index.html#shennong">Herbal highlights</a></li>
-                        <li><a href="famous-tcm-doctors.html">Practitioners</a></li>
+                        <li><a href="index.html#home">首頁</a></li>
+                        <li><a href="index.html#shennong">本草精選</a></li>
+                        <li><a href="famous-tcm-doctors.html">名醫薈萃</a></li>
                     </ul>
                 </div>
                 <div class="footer-section">
-                    <h4>Contact</h4>
+                    <h4>聯絡資訊</h4>
                     <ul>
                         <li><i class="fas fa-envelope"></i> hello@heritagetcm.com</li>
                         <li><i class="fas fa-phone"></i> +1-407-555-1688</li>
@@ -224,7 +224,7 @@
                 </div>
             </div>
             <div class="footer-bottom">
-                <p>&copy; 2024 Heritage TCM. All rights reserved.</p>
+                <p>&copy; 2024 承古堂。保留所有權利。</p>
             </div>
         </div>
     </footer>

--- a/babu-jingang-gong.html
+++ b/babu-jingang-gong.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Ba Bu Jingang Gong | Heritage TCM</title>
-    <meta name="description" content="Advanced Eight Pieces of the Brocade: structure, breathing notes, and training plans for Ba Bu Jingang Gong.">
+    <title>八部金剛功｜承古堂</title>
+    <meta name="description" content="進階八段錦訓練：八部金剛功的動作結構、呼吸要領與訓練計畫。">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 </head>
@@ -13,20 +13,20 @@
         <div class="nav-container">
             <div class="nav-logo">
                 <i class="fas fa-leaf"></i>
-                <span>Heritage TCM</span>
+                <span>承古堂</span>
             </div>
             <ul class="nav-menu">
-                <li class="nav-item"><a href="index.html#home" class="nav-link">Home</a></li>
-                <li class="nav-item"><a href="index.html#books" class="nav-link">Reading List</a></li>
-                <li class="nav-item"><a href="index.html#about" class="nav-link">About</a></li>
-                <li class="nav-item"><a href="zhongyao.html" class="nav-link">Herbal Library</a></li>
-                <li class="nav-item"><a href="babu-jingang-gong.html" class="nav-link active">Ba Bu Jingang Gong</a></li>
-                <li class="nav-item"><a href="ba-duan-jin.html" class="nav-link">Eight Brocades</a></li>
+                <li class="nav-item"><a href="index.html#home" class="nav-link">首頁</a></li>
+                <li class="nav-item"><a href="index.html#books" class="nav-link">經典書單</a></li>
+                <li class="nav-item"><a href="index.html#about" class="nav-link">關於我們</a></li>
+                <li class="nav-item"><a href="zhongyao.html" class="nav-link">本草庫</a></li>
+                <li class="nav-item"><a href="babu-jingang-gong.html" class="nav-link active">八部金剛功</a></li>
+                <li class="nav-item"><a href="ba-duan-jin.html" class="nav-link">八段錦</a></li>
             </ul>
             <div class="nav-actions">
-                <button class="bookmark-btn" id="bookmarkBtn" title="Bookmark this page">
+                <button class="bookmark-btn" id="bookmarkBtn" title="將本頁加入書籤">
                     <i class="fas fa-bookmark"></i>
-                    <span>Bookmark</span>
+                    <span>收藏</span>
                 </button>
             </div>
             <div class="hamburger">
@@ -41,17 +41,17 @@
         <section class="practice-hero jingang-hero">
             <div class="container">
                 <div class="practice-hero-content">
-                    <span class="practice-hero-eyebrow">For seasoned practitioners</span>
-                    <h1 class="practice-hero-title">Ba Bu Jingang Gong</h1>
-                    <p class="practice-hero-subtitle">Also known as the Eight Sections of the Vajra, this routine refines strength, tendon elasticity, and inner stillness. It builds on the foundation of the Eight Brocades with deeper spirals and intent.</p>
+                    <span class="practice-hero-eyebrow">進階練功者之選</span>
+                    <h1 class="practice-hero-title">八部金剛功</h1>
+                    <p class="practice-hero-subtitle">亦稱「金剛八式」，在八段錦基礎上加深旋轉與意念，鍛鍊力量、筋骨彈性與內在沉穩。</p>
                     <ul class="practice-hero-points">
-                        <li><i class="fas fa-dumbbell"></i> Progressive training drills that emphasise rooting and whole-body power.</li>
-                        <li><i class="fas fa-brain"></i> Meditation prompts for each section to stabilise the mind.</li>
-                        <li><i class="fas fa-notes-medical"></i> Safety checkpoints to keep joints open and breath unstrained.</li>
+                        <li><i class="fas fa-dumbbell"></i> 漸進式訓練，強調紮根與整體發力。</li>
+                        <li><i class="fas fa-brain"></i> 每式皆附靜心提示，穩定意念。</li>
+                        <li><i class="fas fa-notes-medical"></i> 安全檢核，保持關節鬆開、呼吸不滯。</li>
                     </ul>
                     <div class="practice-hero-actions">
-                        <a href="#sequence" class="btn btn-primary">Explore the eight sections</a>
-                        <a href="#training" class="btn btn-secondary">Download practice plans</a>
+                        <a href="#sequence" class="btn btn-primary">了解八式要領</a>
+                        <a href="#training" class="btn btn-secondary">下載訓練計畫</a>
                     </div>
                 </div>
             </div>
@@ -60,73 +60,73 @@
         <section class="practice-section" id="sequence">
             <div class="container">
                 <div class="section-header">
-                    <p class="section-eyebrow">Movement breakdown</p>
-                    <h2 class="section-title">Eight sections with intent</h2>
-                    <p class="section-subtitle">Each sequence weaves precise alignment with focused breathwork. Move deliberately, pausing between sections to absorb the sensations.</p>
+                    <p class="section-eyebrow">動作解析</p>
+                    <h2 class="section-title">八式八意</h2>
+                    <p class="section-subtitle">每式結合精準身法與呼吸，請放慢節奏，於段落間短暫停留感受。</p>
                 </div>
                 <div class="jingang-grid">
                     <article>
-                        <h3>1 · Vajra Awakens the Spine</h3>
-                        <p>Raise and lower the arms in arcs while rooting the feet. Imagine the spine unfurling vertebra by vertebra.</p>
+                        <h3>一・金剛喚脊</h3>
+                        <p>雙臂成弧升降，雙足穩根，意守脊椎節節舒展。</p>
                         <ul>
-                            <li>Breath: inhale to lift, exhale to settle the weight into the heels.</li>
-                            <li>Mindset: feel the lower dantian glow as the base of support.</li>
+                            <li>呼吸：吸氣上提，呼氣沉於足跟。</li>
+                            <li>意念：下丹田溫暖發光，支撐全身。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>2 · Vajra Lifts the Sky</h3>
-                        <p>Palms spiral overhead, elbows relaxed. The lifting sensation originates at the sacrum and travels upward.</p>
+                        <h3>二・金剛托天</h3>
+                        <p>雙掌旋托過頂，手肘放鬆，力量由骶骨向上延伸。</p>
                         <ul>
-                            <li>Breath: gather on the inhale, release on the exhale.</li>
-                            <li>Mindset: sense the body as a single column connecting earth and sky.</li>
+                            <li>呼吸：吸氣聚於掌心，呼氣緩釋。</li>
+                            <li>意念：身如一柱，貫通天地。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>3 · Vajra Draws the Bow</h3>
-                        <p>Feet plant wide; torso twists as the arms open diagonally. Engage the waist to lead the movement.</p>
+                        <h3>三・金剛開弓</h3>
+                        <p>雙腳分立，軀幹扭轉，雙臂斜向開展，以腰帶動全身。</p>
                         <ul>
-                            <li>Breath: inhale as you open, exhale as the bow releases.</li>
-                            <li>Mindset: direct intent past the fingertips, steady but powerful.</li>
+                            <li>呼吸：開弓吸氣，放弓呼氣。</li>
+                            <li>意念：神隨指尖延伸，沉穩而有力。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>4 · Vajra Turns the Wheel</h3>
-                        <p>Hands describe a large circle in front of the body. The pelvis remains heavy while the upper body spirals.</p>
+                        <h3>四・金剛轉輪</h3>
+                        <p>雙手於身前畫大圓，骨盆沉穩，上身柔和盤旋。</p>
                         <ul>
-                            <li>Breath: smooth, unbroken; follow the hands with the breath.</li>
-                            <li>Mindset: soften the chest and allow qi to flow through the girdle vessel.</li>
+                            <li>呼吸：綿長不斷，呼吸隨手同行。</li>
+                            <li>意念：胸口柔和，氣行帶脈。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>5 · Vajra Presses the Mountain</h3>
-                        <p>Palms press outward as the knees bend. Maintain length in the spine and a lifted crown.</p>
+                        <h3>五・金剛推山</h3>
+                        <p>屈膝時雙掌向外推，脊柱拔長，百會上領。</p>
                         <ul>
-                            <li>Breath: exhale with the press to engage the core.</li>
-                            <li>Mindset: cultivate quiet strength, as if holding space for the body to expand.</li>
+                            <li>呼吸：隨推掌呼氣，啟動核心。</li>
+                            <li>意念：凝養靜力，為身體開拓空間。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>6 · Vajra Polishes the Pillar</h3>
-                        <p>Alternating hands sweep along the spine, massaging the governor vessel. Coordinate with subtle flexion and extension.</p>
+                        <h3>六・金剛磨柱</h3>
+                        <p>雙手交替沿脊柱掃動，按摩督脈，配合細微屈伸。</p>
                         <ul>
-                            <li>Breath: match the sweep of the hands to inhaling up and exhaling down.</li>
-                            <li>Mindset: imagine clearing obstructions so qi can rise smoothly.</li>
+                            <li>呼吸：上行吸氣，下行呼氣。</li>
+                            <li>意念：掃淨阻滯，讓氣順暢升發。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>7 · Vajra Offers the Cauldron</h3>
-                        <p>Arms cradle an invisible vessel forward, then draw it back to the dantian. Knees and hips move as one.</p>
+                        <h3>七・金剛捧鼎</h3>
+                        <p>雙臂托持虛鼎向前，隨後回收至丹田，屈伸時膝髖協調。</p>
                         <ul>
-                            <li>Breath: inhale to gather, exhale to present.</li>
-                            <li>Mindset: nourish the heart and lungs with expansive intention.</li>
+                            <li>呼吸：吸氣聚鼎，呼氣奉出。</li>
+                            <li>意念：擴展心肺之氣。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>8 · Vajra Returns to Stillness</h3>
-                        <p>Hands settle over the lower abdomen. Stand quietly, allowing micro-movements to ripple and fade.</p>
+                        <h3>八・金剛歸靜</h3>
+                        <p>雙手覆於丹田，靜站觀照，讓細微波動自然沉靜。</p>
                         <ul>
-                            <li>Breath: natural, delicate, almost imperceptible.</li>
-                            <li>Mindset: observe the body’s internal resonance without judgment.</li>
+                            <li>呼吸：自然細長，若有若無。</li>
+                            <li>意念：觀聽內在共鳴，淡然不加評斷。</li>
                         </ul>
                     </article>
                 </div>
@@ -136,43 +136,43 @@
         <section class="practice-section" id="training">
             <div class="container">
                 <div class="section-header">
-                    <p class="section-eyebrow">Training blueprint</p>
-                    <h2 class="section-title">Build your practice</h2>
-                    <p class="section-subtitle">Adapt the routine to match your experience level and daily energy.</p>
+                    <p class="section-eyebrow">訓練藍圖</p>
+                    <h2 class="section-title">建構專屬練習</h2>
+                    <p class="section-subtitle">依個人經驗與精力，調整練習強度與安排。</p>
                 </div>
                 <div class="training-grid">
                     <article>
-                        <h3>Foundation cycle</h3>
-                        <p>Three sessions per week · 25 minutes each</p>
+                        <h3>基礎循環</h3>
+                        <p>每週 3 次｜每次約 25 分鐘</p>
                         <ul>
-                            <li>Warm-up with standing meditation and joint rotations.</li>
-                            <li>Practise sections 1–4 with five breaths per posture.</li>
-                            <li>Finish with a gentle seated breathing exercise.</li>
+                            <li>先以站樁與關節活動暖身。</li>
+                            <li>練習第 1 至 4 式，每式配五個呼吸。</li>
+                            <li>收功時靜坐調息。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>Integration cycle</h3>
-                        <p>Four sessions per week · 35 minutes each</p>
+                        <h3>融合循環</h3>
+                        <p>每週 4 次｜每次約 35 分鐘</p>
                         <ul>
-                            <li>Add sections 5–8, emphasising smooth transitions.</li>
-                            <li>Record observations in a practice journal.</li>
-                            <li>Alternate evening and morning sessions to feel different energetic qualities.</li>
+                            <li>加入第 5 至 8 式，留意過渡流暢度。</li>
+                            <li>以練功筆記記錄感受。</li>
+                            <li>早晚交替練習，體驗氣機差異。</li>
                         </ul>
                     </article>
                     <article>
-                        <h3>Refinement cycle</h3>
-                        <p>Five sessions per week · 45 minutes each</p>
+                        <h3>精煉循環</h3>
+                        <p>每週 5 次｜每次約 45 分鐘</p>
                         <ul>
-                            <li>Include silk-reeling drills between sections for tendon conditioning.</li>
-                            <li>Introduce partner feedback or mirror work once a week.</li>
-                            <li>Conclude with quiet standing to sense micro-circulation.</li>
+                            <li>各式之間穿插纏絲功，鍛鍊筋膜。</li>
+                            <li>每週一次與同伴互評或利用鏡面自查。</li>
+                            <li>結束後站樁，感受微循環。</li>
                         </ul>
                     </article>
                 </div>
                 <div class="download-card">
-                    <h3>Printable training journal</h3>
-                    <p>Track session length, perceived exertion, and qi sensations. Use the QR code to access guided audio prompts.</p>
-                    <a href="#" class="btn btn-primary">Download PDF</a>
+                    <h3>可列印練功筆記</h3>
+                    <p>記錄每次時長、力度與氣感，掃描 QR Code 可收聽語音引導。</p>
+                    <a href="#" class="btn btn-primary">下載 PDF</a>
                 </div>
             </div>
         </section>
@@ -182,19 +182,19 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-section">
-                    <h3>Heritage TCM</h3>
-                    <p>Dedicated to carrying classical wisdom into everyday practice.</p>
+                    <h3>承古堂</h3>
+                    <p>致力將經典智慧落實於現代生活。</p>
                 </div>
                 <div class="footer-section">
-                    <h4>Quick Links</h4>
+                    <h4>快速連結</h4>
                     <ul>
-                        <li><a href="index.html#home">Home</a></li>
-                        <li><a href="index.html#faq">FAQ</a></li>
-                        <li><a href="famous-tcm-doctors.html">Practitioners</a></li>
+                        <li><a href="index.html#home">首頁</a></li>
+                        <li><a href="index.html#faq">常見問題</a></li>
+                        <li><a href="famous-tcm-doctors.html">名醫薈萃</a></li>
                     </ul>
                 </div>
                 <div class="footer-section">
-                    <h4>Contact</h4>
+                    <h4>聯絡資訊</h4>
                     <ul>
                         <li><i class="fas fa-envelope"></i> hello@heritagetcm.com</li>
                         <li><i class="fas fa-phone"></i> +1-407-555-1688</li>
@@ -202,7 +202,7 @@
                 </div>
             </div>
             <div class="footer-bottom">
-                <p>&copy; 2024 Heritage TCM. All rights reserved.</p>
+                <p>&copy; 2024 承古堂。保留所有權利。</p>
             </div>
         </div>
     </footer>

--- a/data/shennong-herbs.js
+++ b/data/shennong-herbs.js
@@ -1,147 +1,147 @@
 const shennongHerbs = [
   {
     id: 1,
-    name: 'Ren Shen (Ginseng)',
+    name: '人參（Ren Shen）',
     grade: 'Superior',
-    classicalText: 'Shennong says: sweet and slightly cool. Replenishes the five zang, calms the spirit, settles palpitations, and extends life when taken regularly.'
+    classicalText: '神農曰：味甘微寒，補五臟，安精神，止驚悸，久服輕身延年。'
   },
   {
     id: 2,
-    name: 'Dang Gui (Angelica Root)',
+    name: '當歸（Dang Gui）',
     grade: 'Superior',
-    classicalText: 'Sweet and warm. Nourishes and moves the blood, warms the center, and relieves pain. Long-term use keeps the complexion vibrant.'
+    classicalText: '味甘辛而溫，補血活血，溫中止痛，久服潤澤容顏。'
   },
   {
     id: 3,
-    name: 'Huang Qi (Astragalus)',
+    name: '黃耆（Huang Qi）',
     grade: 'Superior',
-    classicalText: 'Sweet and slightly warm. Fortifies qi, lifts yang, supports recovery from fatigue, and protects against wind.'
+    classicalText: '味甘微溫，補氣舉陽，托毒生肌，固表禦風。'
   },
   {
     id: 4,
-    name: 'Gan Cao (Licorice)',
+    name: '甘草（Gan Cao）',
     grade: 'Superior',
-    classicalText: 'Sweet and neutral. Harmonises formulas, eases spasms, soothes sore throats, and moderates toxicity.'
+    classicalText: '味甘平，調和諸藥，緩急止痛，潤肺解毒，和中護咽。'
   },
   {
     id: 5,
-    name: 'Gui Zhi (Cinnamon Twig)',
+    name: '桂枝（Gui Zhi）',
     grade: 'Superior',
-    classicalText: 'Pungent and warm. Warms the channels, promotes circulation, releases exterior cold, and supports healthy sweating.'
+    classicalText: '味辛甘而溫，溫通經脈，發散風寒，調和營衛，助汗達表。'
   },
   {
     id: 6,
-    name: 'Sheng Jiang (Fresh Ginger)',
+    name: '生薑（Sheng Jiang）',
     grade: 'Superior',
-    classicalText: 'Pungent and warm. Warms the middle, stops nausea, alleviates cough, and resolves surface-level wind-cold.'
+    classicalText: '味辛溫，溫胃散寒，止嘔化痰，解魚蟹之毒，表散風寒。'
   },
   {
     id: 7,
-    name: 'Mai Men Dong (Ophiopogon)',
+    name: '麥門冬（Mai Men Dong）',
     grade: 'Superior',
-    classicalText: 'Sweet and slightly cold. Nourishes yin of the stomach and lungs, generates fluids, and eases dry cough.'
+    classicalText: '味甘微寒，養胃肺之陰，生津潤燥，止咳清心。'
   },
   {
     id: 8,
-    name: 'Shi Hu (Dendrobium)',
+    name: '石斛（Shi Hu）',
     grade: 'Superior',
-    classicalText: 'Sweet and cool. Enriches yin, clears deficiency heat, and sharpens vision when used consistently.'
+    classicalText: '味甘淡而微寒，養陰清熱，益胃生津，久服明目強腰膝。'
   },
   {
     id: 9,
-    name: 'Fu Ling (Poria)',
+    name: '茯苓（Fu Ling）',
     grade: 'Superior',
-    classicalText: 'Sweet and neutral. Leaches dampness, calms the heart spirit, and supports digestion.'
+    classicalText: '味甘淡平，滲濕利水，健脾安神，和胃助運化。'
   },
   {
     id: 10,
-    name: 'Bai Zhu (Atractylodes Macrocephala)',
+    name: '白朮（Bai Zhu）',
     grade: 'Superior',
-    classicalText: 'Bitter and warm. Strengthens spleen qi, dries dampness, and helps retain body fluids.'
+    classicalText: '味苦甘溫，健脾益氣，燥濕利水，固表攝汗。'
   },
   {
     id: 11,
-    name: 'Wu Wei Zi (Schisandra)',
+    name: '五味子（Wu Wei Zi）',
     grade: 'Superior',
-    classicalText: 'Pungent, sweet, and sour. Astringes lung qi, nourishes the kidneys, and steadies the spirit.'
+    classicalText: '味酸甘溫，斂肺止咳，滋腎寧心，固精攝汗，益氣生津。'
   },
   {
     id: 12,
-    name: 'Shu Di Huang (Prepared Rehmannia)',
+    name: '熟地黃（Shu Di Huang）',
     grade: 'Superior',
-    classicalText: 'Sweet and warm. Replenishes blood and essence, nourishes yin, and anchors deficiency fire.'
+    classicalText: '味甘微溫，滋陰補血，填精補髓，鎮攝虛火。'
   },
   {
     id: 13,
-    name: 'Chen Pi (Aged Tangerine Peel)',
+    name: '陳皮（Chen Pi）',
     grade: 'Medium',
-    classicalText: 'Pungent and bitter, slightly warm. Regulates qi, dries dampness, resolves phlegm, and refreshes the middle burner when stagnation lingers.'
+    classicalText: '味辛苦微溫，理氣健脾，燥濕化痰，醒脾和中。'
   },
   {
     id: 14,
-    name: 'Ban Xia (Pinellia Rhizome)',
+    name: '半夏（Ban Xia）',
     grade: 'Medium',
-    classicalText: 'Acrid and warm yet slightly toxic. Dries dampness, transforms phlegm, descends rebellious qi, and relieves nodules when prepared properly.'
+    classicalText: '味辛溫而有小毒，燥濕化痰，降逆止嘔，散結消痞，須炮製乃可用。'
   },
   {
     id: 15,
-    name: 'Fu Zi (Prepared Aconite)',
+    name: '附子（Fu Zi）',
     grade: 'Medium',
-    classicalText: 'Acrid, very hot, and toxic. Restores devastated yang, warms the fire at the gate of vitality, and dispels cold from the channels once detoxified.'
+    classicalText: '味辛大熱有毒，回陽救逆，補火助陽，散寒止痛，炮制去毒方可。'
   },
   {
     id: 16,
-    name: 'Hou Po (Magnolia Bark)',
+    name: '厚朴（Hou Po）',
     grade: 'Medium',
-    classicalText: 'Bitter and warm with a fragrant lift. Moves qi, dries damp, calms wheezing, and eases food stagnation in the chest and abdomen.'
+    classicalText: '味苦辛溫而香，行氣燥濕，下氣平喘，消除滿悶積滯。'
   },
   {
     id: 17,
-    name: 'Cang Zhu (Atractylodes Lancea)',
+    name: '蒼朮（Cang Zhu）',
     grade: 'Medium',
-    classicalText: 'Pungent and warm. Dries dampness, fortifies the spleen, dispels wind-cold-damp, and brightens the eyes when used steadily.'
+    classicalText: '味辛苦溫，燥濕健脾，祛風散寒，明目助運。'
   },
   {
     id: 18,
-    name: 'Zhi Ke (Bitter Orange)',
+    name: '枳殼（Zhi Ke）',
     grade: 'Medium',
-    classicalText: 'Bitter and slightly cold. Regulates qi, relieves distention, transforms phlegm, and assists in moving food accumulations.'
+    classicalText: '味苦微寒，行氣寬中，消脹除痞，化痰行滯。'
   },
   {
     id: 19,
-    name: 'Da Huang (Rhubarb Root)',
+    name: '大黃（Da Huang）',
     grade: 'Regular',
-    classicalText: 'Bitter and cold. Purges accumulations, clears heat, moves blood stasis, and drains damp-heat when used briefly.'
+    classicalText: '味苦寒，攻下積滯，清熱解毒，破瘀通經，善走血分。'
   },
   {
     id: 20,
-    name: 'Mang Xiao (Mirabilite)',
+    name: '芒硝（Mang Xiao）',
     grade: 'Regular',
-    classicalText: 'Salty and very cold. Softens hardness, moistens dryness, clears heat, and relieves constipation by guiding water downward.'
+    classicalText: '味鹹寒，軟堅潤燥，清熱通便，引水下行。'
   },
   {
     id: 21,
-    name: 'Gan Sui (Kansui Root)',
+    name: '甘遂（Gan Sui）',
     grade: 'Regular',
-    classicalText: 'Bitter, sweet, and cold with marked toxicity. Drives out congested fluids, reduces swelling, and opens bowels in severe water build-up.'
+    classicalText: '味苦甘寒有毒，瀉逐水飲，消腫散結，逐痰開閉，須慎量用。'
   },
   {
     id: 22,
-    name: 'Ba Dou (Croton Seed)',
+    name: '巴豆（Ba Dou）',
     grade: 'Regular',
-    classicalText: 'Acrid, warm, and intensely toxic. Powerfully purges cold accumulation, drives out thin mucus, and bursts clumped qi when expertly administered.'
+    classicalText: '味辛熱劇毒，峻下寒積，逐水退腫，豁痰破滯，當專業慎用。'
   },
   {
     id: 23,
-    name: 'Qian Niu Zi (Morning Glory Seed)',
+    name: '牽牛子（Qian Niu Zi）',
     grade: 'Regular',
-    classicalText: 'Bitter and cold, slightly toxic. Drains water, dispels phlegm, breaks accumulations, and expels parasites.'
+    classicalText: '味苦寒微毒，瀉水消腫，逐痰破積，殺蟲去濕。'
   },
   {
     id: 24,
-    name: 'Yu Li Ren (Bush Cherry Pit)',
+    name: '郁李仁（Yu Li Ren）',
     grade: 'Regular',
-    classicalText: 'Sweet and neutral. Moistens the intestines, unblocks the bowels, promotes urination, and relieves edema with gentle action.'
+    classicalText: '味甘苦平，潤腸通便，利水消腫，動而不峻，尤宜津虧便秘。'
   }
 ];
 

--- a/famous-doctors/bian-que.html
+++ b/famous-doctors/bian-que.html
@@ -1,42 +1,42 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Bian Que | Influential TCM Practitioners</title>
-    <meta name="description" content="Biography of Bian Que, legendary diagnostician of the Warring States period.">
+    <title>扁鵲｜影響力中醫名家</title>
+    <meta name="description" content="扁鵲生平傳說，體現望聞問切與未病先防的醫道精神。">
     <link rel="stylesheet" href="../styles.css">
 </head>
 <body class="master-profile">
-    <a class="back-link" href="../famous-tcm-doctors.html">←<span>Back to influential practitioners</span></a>
+    <a class="back-link" href="../famous-tcm-doctors.html">←<span>返回影響力名家列表</span></a>
     <main class="profile-container">
         <header>
-            <h1>Bian Que</h1>
-            <p class="profile-tagline">Master of the four examinations</p>
-            <p class="profile-era">Warring States · ca. 407–310 BCE</p>
+            <h1>扁鵲</h1>
+            <p class="profile-tagline">望聞問切宗師</p>
+            <p class="profile-era">戰國．約前 407–310 年</p>
         </header>
         <section>
-            <h2>Biography</h2>
-            <p>Bian Que, born Qin Yueren, is often credited as the ancestor of Chinese medicine. Legends recount his ability to see subtle imbalances before they erupted into illness, offering the famous warning to the ruler of Cai that disease must be treated while still superficial.</p>
-            <p>Though mythic in tone, these stories highlight the value TCM places on early detection and preventive care.</p>
+            <h2>生平小傳</h2>
+            <p>扁鵲，名秦越人，被尊為中醫鼻祖。傳說他洞察未發之病，曾勸蔡桓公「疾在腠理，當汗而出」，彰顯病未深時即應治療的理念。</p>
+            <p>雖帶神話色彩，卻凸顯中醫重視早期診察與預防養生的價值。</p>
         </section>
         <section>
-            <h2>Clinical Focus</h2>
-            <p>Holistic diagnosis through looking, listening, questioning, and palpating, along with the use of acupuncture and herbal intervention.</p>
+            <h2>臨床專長</h2>
+            <p>綜合望、聞、問、切四診辨證，並靈活運用針灸與方藥治療。</p>
         </section>
         <section>
-            <h2>Key Contributions</h2>
+            <h2>重要貢獻</h2>
             <ul>
-                <li>Popularised the four diagnostic pillars that remain central to clinical encounters.</li>
-                <li>Symbolises the ethic of “treating before disease arises.”</li>
-                <li>Expanded the reach of acupuncture and pulse diagnosis in early China.</li>
+                <li>弘揚望聞問切四診為臨床根本。</li>
+                <li>體現「治未病」的醫學倫理。</li>
+                <li>推動針灸與脈診在早期中國的普及。</li>
             </ul>
         </section>
         <section>
-            <h2>Legacy Note</h2>
-            <p>Bian Que’s legend reminds us that attentive observation can redirect the course of illness. His name has become synonymous with trustworthy, perceptive care.</p>
+            <h2>後世評述</h2>
+            <p>扁鵲故事提醒醫者時時察微知著，善於觀察即可改變病程，其名已成為洞察細膩與信賴醫術的象徵。</p>
         </section>
-        <footer>Return to the <a href="../index.html">Heritage TCM homepage</a>.</footer>
+        <footer>回到 <a href="../index.html">承古堂首頁</a></footer>
     </main>
 </body>
 </html>

--- a/famous-doctors/hua-tuo.html
+++ b/famous-doctors/hua-tuo.html
@@ -1,49 +1,49 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Hua Tuo | Influential TCM Practitioners</title>
-    <meta name="description" content="Biography of Hua Tuo, surgical pioneer and creator of the Five Animal Frolics exercises.">
+    <title>華佗｜影響力中醫名家</title>
+    <meta name="description" content="華佗生平事蹟，認識麻沸散與五禽戲對醫學養生的貢獻。">
     <link rel="stylesheet" href="../styles.css">
 </head>
 <body class="master-profile">
-    <a class="back-link" href="../famous-tcm-doctors.html">←<span>Back to influential practitioners</span></a>
+    <a class="back-link" href="../famous-tcm-doctors.html">←<span>返回影響力名家列表</span></a>
     <main class="profile-container">
         <header>
-            <h1>Hua Tuo</h1>
-            <p class="profile-tagline">Surgical innovator</p>
-            <p class="profile-era">Late Eastern Han · ca. 145–208 CE</p>
+            <h1>華佗</h1>
+            <p class="profile-tagline">外科先驅</p>
+            <p class="profile-era">東漢晚期．約 145–208 年</p>
         </header>
         <section>
-            <h2>Biography</h2>
-            <p>Hua Tuo studied widely and travelled light, serving both generals and common villagers. He perfected a herbal anaesthetic known as “mafeisan” and was famed for daring procedures, including the legendary scraping of poison from Guan Yu’s arm.</p>
-            <p>When not treating wounds, he taught the Five Animal Frolics, a qigong sequence inspired by the movements of the tiger, deer, bear, ape, and crane.</p>
+            <h2>生平小傳</h2>
+            <p>華佗遊學各地，行醫無礙，既治戎馬將士亦施醫於百姓。創製草藥麻醉「麻沸散」，以膽識超群的外科手術聞名，關羽刮骨療毒的故事廣為流傳。</p>
+            <p>閒時教授「五禽戲」，取虎、鹿、熊、猿、鶴之動作化為氣功導引，調暢筋骨氣血。</p>
         </section>
         <section>
-            <h2>Clinical Focus</h2>
-            <p>Trauma surgery, wound care, anaesthesia, and restorative movement.</p>
+            <h2>臨床專長</h2>
+            <p>創傷外科、創口處理、麻醉運用與導引修復功法。</p>
         </section>
         <section>
-            <h2>Key Contributions</h2>
+            <h2>重要貢獻</h2>
             <ul>
-                <li>Introduced herbal anaesthesia that enabled deep surgical interventions.</li>
-                <li>Demonstrated post-operative rehabilitation through targeted exercises.</li>
-                <li>Bridged martial, medical, and longevity arts with equal grace.</li>
+                <li>發明草藥麻醉，使深度手術得以安全進行。</li>
+                <li>倡導術後導引鍛鍊，協助傷者復原。</li>
+                <li>融會武術、醫術與養生術，開啟全人照護視野。</li>
             </ul>
         </section>
         <section>
-            <h2>Recommended Reading</h2>
+            <h2>延伸閱讀</h2>
             <ul>
-                <li>Historical accounts in the <em>Records of the Three Kingdoms</em></li>
-                <li>Modern reconstructions of the Five Animal Frolics</li>
+                <li><em>三國志</em>相關史料</li>
+                <li>現代五禽戲復原教材</li>
             </ul>
         </section>
         <section>
-            <h2>Legacy Note</h2>
-            <p>Hua Tuo’s fearless experimentation foreshadows today’s integrative pain management. His exercises continue to inspire practitioners seeking gentle strength and mobility.</p>
+            <h2>後世評述</h2>
+            <p>華佗勇於創新，啟迪當代疼痛醫學的整合思維；五禽戲亦成為追求柔韌與活力者的養生經典。</p>
         </section>
-        <footer>Return to the <a href="../index.html">Heritage TCM homepage</a>.</footer>
+        <footer>回到 <a href="../index.html">承古堂首頁</a></footer>
     </main>
 </body>
 </html>

--- a/famous-doctors/li-dongyuan.html
+++ b/famous-doctors/li-dongyuan.html
@@ -1,48 +1,48 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Li Dongyuan | Influential TCM Practitioners</title>
-    <meta name="description" content="Biography of Li Dongyuan, founder of the Spleen and Stomach school of Traditional Chinese Medicine.">
+    <title>李東垣｜影響力中醫名家</title>
+    <meta name="description" content="李東垣生平與脾胃學派，認識補土派對脾胃氣虛的療法。">
     <link rel="stylesheet" href="../styles.css">
 </head>
 <body class="master-profile">
-    <a class="back-link" href="../famous-tcm-doctors.html">←<span>Back to influential practitioners</span></a>
+    <a class="back-link" href="../famous-tcm-doctors.html">←<span>返回影響力名家列表</span></a>
     <main class="profile-container">
         <header>
-            <h1>Li Dongyuan</h1>
-            <p class="profile-tagline">Champion of spleen and stomach qi</p>
-            <p class="profile-era">Jin dynasty · 1180–1251 CE</p>
+            <h1>李東垣</h1>
+            <p class="profile-tagline">脾胃派宗師</p>
+            <p class="profile-era">金朝．1180–1251 年</p>
         </header>
         <section>
-            <h2>Biography</h2>
-            <p>Li Dongyuan, also known as Li Gao, practised during a time of war-induced famine and emotional strain. He observed that chronic fatigue, digestive weakness, and lingering dampness stemmed from depleted middle burner qi.</p>
-            <p>His school emphasises nourishing earth, raising clear yang, and gently dispersing damp-heat so that the body can recover its own momentum.</p>
+            <h2>生平小傳</h2>
+            <p>李東垣，亦名李杲，處於戰亂飢饉之世，見人多勞倦思慮，脾胃虛弱、濕濁纏綿，認為皆由中焦氣虛所致。</p>
+            <p>他倡導補土培元，升清降濁，兼以淡滲除濕，使身體恢復自我運化。</p>
         </section>
         <section>
-            <h2>Clinical Focus</h2>
-            <p>Strengthening digestion, treating chronic fatigue, and restoring the transformative power of qi through warm, sweet, and ascending herbs.</p>
+            <h2>臨床專長</h2>
+            <p>以溫甘升提之品補脾胃、治勞倦、化濕濁，重建氣機升降。</p>
         </section>
         <section>
-            <h2>Key Contributions</h2>
+            <h2>重要貢獻</h2>
             <ul>
-                <li>Developed flagship formulas such as Bu Zhong Yi Qi Tang and Shen Ling Bai Zhu San.</li>
-                <li>Linked emotional stress and overwork to spleen qi deficiency.</li>
-                <li>Balanced tonification with gentle clearing to prevent cloying stagnation.</li>
+                <li>創立補土代表方，如補中益氣湯、參苓白朮散。</li>
+                <li>指出思慮過度、勞倦損傷易致脾氣虛。</li>
+                <li>補中兼以淡滲清化，避免黏膩壅滯。</li>
             </ul>
         </section>
         <section>
-            <h2>Recommended Reading</h2>
+            <h2>延伸閱讀</h2>
             <ul>
-                <li><em>Pi Wei Lun</em> (Treatise on the Spleen and Stomach)</li>
+                <li><em>脾胃論</em></li>
             </ul>
         </section>
         <section>
-            <h2>Legacy Note</h2>
-            <p>Li’s insights guide many modern clinicians who treat burnout, digestive disorders, and long-haul recovery. His formulas remain staples for gently rebuilding resilience.</p>
+            <h2>後世評述</h2>
+            <p>李氏見解成為現代調理疲勞、脾胃失和與長期康復的重要依據，其方藥至今仍常用於溫補兼清的療程。</p>
         </section>
-        <footer>Return to the <a href="../index.html">Heritage TCM homepage</a>.</footer>
+        <footer>回到 <a href="../index.html">承古堂首頁</a></footer>
     </main>
 </body>
 </html>

--- a/famous-doctors/li-shizhen.html
+++ b/famous-doctors/li-shizhen.html
@@ -1,48 +1,48 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Li Shizhen | Influential TCM Practitioners</title>
-    <meta name="description" content="Biography of Li Shizhen, author of the Compendium of Materia Medica and champion of empirical herbal study.">
+    <title>李時珍｜影響力中醫名家</title>
+    <meta name="description" content="李時珍生平與《本草綱目》要點，呈現其實證本草精神。">
     <link rel="stylesheet" href="../styles.css">
 </head>
 <body class="master-profile">
-    <a class="back-link" href="../famous-tcm-doctors.html">←<span>Back to influential practitioners</span></a>
+    <a class="back-link" href="../famous-tcm-doctors.html">←<span>返回影響力名家列表</span></a>
     <main class="profile-container">
         <header>
-            <h1>Li Shizhen</h1>
-            <p class="profile-tagline">Botanical encyclopedist</p>
-            <p class="profile-era">Ming dynasty · 1518–1593 CE</p>
+            <h1>李時珍</h1>
+            <p class="profile-tagline">本草博物學家</p>
+            <p class="profile-era">明朝．1518–1593 年</p>
         </header>
         <section>
-            <h2>Biography</h2>
-            <p>Li Shizhen travelled extensively across China’s mountains and wetlands, tasting and cataloguing plants alongside farmers, hunters, and fishermen. Dissatisfied with errors that had crept into medical texts, he verified each entry through meticulous observation.</p>
-            <p>His three-decade project culminated in the <em>Bencao Gangmu</em>, an illustrated encyclopedia that ties botanical description, medicinal properties, and cultural usage together.</p>
+            <h2>生平小傳</h2>
+            <p>李時珍行遍山川湖澤，與採藥人、獵人、漁民同尋草木，親嚐辨識；對醫籍錯誤深感不滿，遂以細緻觀察逐條核實。</p>
+            <p>歷經三十年編成《本草綱目》，以圖文並陳方式統合植物形態、藥性功效與民俗應用。</p>
         </section>
         <section>
-            <h2>Clinical Focus</h2>
-            <p>Materia medica research, accurate identification of herbs, and integrating food therapy with therapeutic prescriptions.</p>
+            <h2>臨床專長</h2>
+            <p>致力本草考據、嚴謹辨識藥材，並強調藥食同源的運用。</p>
         </section>
         <section>
-            <h2>Key Contributions</h2>
+            <h2>重要貢獻</h2>
             <ul>
-                <li>Documented 1,892 substances, many with notes on harvesting, processing, and toxicity.</li>
-                <li>Introduced hundreds of corrections and cross-references to earlier texts.</li>
-                <li>Showed how climate, geography, and preparation change an herb’s potency.</li>
+                <li>收錄 1,892 種藥材，詳述採集、炮製與毒性注意。</li>
+                <li>校正前代錯誤，補充大量互參資料。</li>
+                <li>闡明氣候、產地與炮製對藥性力度的影響。</li>
             </ul>
         </section>
         <section>
-            <h2>Recommended Reading</h2>
+            <h2>延伸閱讀</h2>
             <ul>
-                <li><em>Bencao Gangmu</em> (Compendium of Materia Medica)</li>
+                <li><em>本草綱目</em></li>
             </ul>
         </section>
         <section>
-            <h2>Legacy Note</h2>
-            <p>Li’s fieldwork inspires today’s herbalists to respect both scientific testing and community wisdom. His insistence on accuracy underpins modern quality-control standards.</p>
+            <h2>後世評述</h2>
+            <p>李氏踏查精神啟發今日本草學者兼顧科學檢驗與民間智慧，他對精準的堅持成為藥材品質控管的依據。</p>
         </section>
-        <footer>Return to the <a href="../index.html">Heritage TCM homepage</a>.</footer>
+        <footer>回到 <a href="../index.html">承古堂首頁</a></footer>
     </main>
 </body>
 </html>

--- a/famous-doctors/ni-haixia.html
+++ b/famous-doctors/ni-haixia.html
@@ -1,49 +1,49 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Ni Hai-Xia | Influential TCM Practitioners</title>
-    <meta name="description" content="Biography of Dr. Ni Hai-Xia, modern teacher who brought classical formulas to international audiences.">
+    <title>倪海廈｜影響力中醫名家</title>
+    <meta name="description" content="倪海廈醫師生平與教學風格，介紹其推廣經方於全球的貢獻。">
     <link rel="stylesheet" href="../styles.css">
 </head>
 <body class="master-profile">
-    <a class="back-link" href="../famous-tcm-doctors.html">←<span>Back to influential practitioners</span></a>
+    <a class="back-link" href="../famous-tcm-doctors.html">←<span>返回影響力名家列表</span></a>
     <main class="profile-container">
         <header>
-            <h1>Ni Hai-Xia</h1>
-            <p class="profile-tagline">Classical formulas for modern lives</p>
-            <p class="profile-era">Contemporary · 1954–2012 CE</p>
+            <h1>倪海廈</h1>
+            <p class="profile-tagline">以經方照亮現代人生</p>
+            <p class="profile-era">當代．1954–2012 年</p>
         </header>
         <section>
-            <h2>Biography</h2>
-            <p>Dr. Ni Hai-Xia trained in Taiwan and later founded Han Tang Chinese Medicine in the United States. Through seminars, books, and video lessons he introduced English-speaking students to the intricacies of the <em>Shang Han Lun</em> and <em>Jinkui Yaolue</em>.</p>
-            <p>He combined astronomy, channel theory, and classical herbalism with vivid storytelling, making the tradition approachable without diluting its rigor.</p>
+            <h2>生平小傳</h2>
+            <p>倪海廈醫師早年受業於臺灣，後在美國創立漢唐中醫，透過講座、著作與影音課程，向全球學員介紹《傷寒論》《金匱要略》的辨證精髓。</p>
+            <p>他融合天文曆法、經絡理論與經方實務，以生動故事傳達，既親切又不失嚴謹。</p>
         </section>
         <section>
-            <h2>Clinical Focus</h2>
-            <p>Classical prescription application, seasonal health management, and patient education across global communities.</p>
+            <h2>臨床專長</h2>
+            <p>善用經方調理，重視節氣養生，並推廣病患教育於跨文化社群。</p>
         </section>
         <section>
-            <h2>Key Contributions</h2>
+            <h2>重要貢獻</h2>
             <ul>
-                <li>Created multimedia courses that made classical Chinese texts accessible to English-speaking practitioners.</li>
-                <li>Emphasised personal cultivation, astronomy, and calendar science in diagnosis.</li>
-                <li>Inspired an international network of clinicians dedicated to formula-based care.</li>
+                <li>製作多媒體課程，使經典中醫文本為英語世界所理解。</li>
+                <li>強調修身養性、天文曆法於臨床診斷的重要性。</li>
+                <li>啟發全球經方臨床社群，形成互助學習的網絡。</li>
             </ul>
         </section>
         <section>
-            <h2>Recommended Reading</h2>
+            <h2>延伸閱讀</h2>
             <ul>
-                <li><em>Classical Formulas for Today’s Practitioner</em></li>
-                <li><em>Between Heaven and Earth: Understanding the Universe of Chinese Medicine</em></li>
+                <li><em>當代經方醫案</em></li>
+                <li><em>天紀行醫手記</em></li>
             </ul>
         </section>
         <section>
-            <h2>Legacy Note</h2>
-            <p>Dr. Ni’s teachings continue through study groups, digital archives, and dedicated clinics. His warmth and precision remind us that the classics live through the people who teach and apply them.</p>
+            <h2>後世評述</h2>
+            <p>倪醫師的課程透過研習社群與數位資料延續，他的熱忱與精準讓經典在實際臨床中持續發光。</p>
         </section>
-        <footer>Return to the <a href="../index.html">Heritage TCM homepage</a>.</footer>
+        <footer>回到 <a href="../index.html">承古堂首頁</a></footer>
     </main>
 </body>
 </html>

--- a/famous-doctors/qi-bo.html
+++ b/famous-doctors/qi-bo.html
@@ -1,42 +1,42 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Qi Bo | Influential TCM Practitioners</title>
-    <meta name="description" content="Biography of Qi Bo, the legendary physician who dialogues with the Yellow Emperor in the Huangdi Neijing.">
+    <title>岐伯｜影響力中醫名家</title>
+    <meta name="description" content="岐伯在《黃帝內經》中的對話，象徵中醫陰陽五行與養生智慧。">
     <link rel="stylesheet" href="../styles.css">
 </head>
 <body class="master-profile">
-    <a class="back-link" href="../famous-tcm-doctors.html">←<span>Back to influential practitioners</span></a>
+    <a class="back-link" href="../famous-tcm-doctors.html">←<span>返回影響力名家列表</span></a>
     <main class="profile-container">
         <header>
-            <h1>Qi Bo</h1>
-            <p class="profile-tagline">Advisor to the Yellow Emperor</p>
-            <p class="profile-era">Mythic antiquity</p>
+            <h1>岐伯</h1>
+            <p class="profile-tagline">黃帝御醫</p>
+            <p class="profile-era">上古傳說</p>
         </header>
         <section>
-            <h2>Biography</h2>
-            <p>Qi Bo appears in the <em>Huangdi Neijing</em> as the wise minister answering the Yellow Emperor’s questions about physiology, pathology, and longevity. Though a mythical figure, his teachings represent collective wisdom gathered from early physicians.</p>
-            <p>The dialogues cover seasonal living, the functions of the five zang and six fu, meridians, and the importance of harmonising with nature.</p>
+            <h2>生平小傳</h2>
+            <p>岐伯於《黃帝內經》中以智臣之姿，回答黃帝關於生理、病理與養生的提問。雖具傳說色彩，卻承載早期醫者的集體智慧。</p>
+            <p>對話內容涵蓋四時養生、五臟六腑功能、經脈運行與順應自然之道。</p>
         </section>
         <section>
-            <h2>Clinical Focus</h2>
-            <p>Holistic cosmology, preventive health, and the theoretical bedrock of Traditional Chinese Medicine.</p>
+            <h2>臨床專長</h2>
+            <p>奠定中醫宇宙觀、預防醫學與理論根基。</p>
         </section>
         <section>
-            <h2>Key Contributions</h2>
+            <h2>重要貢獻</h2>
             <ul>
-                <li>Articulated yin-yang and five phase theory as applied to human health.</li>
-                <li>Explained the circulation of qi and blood through the twelve primary channels.</li>
-                <li>Linked emotions, seasons, and lifestyle to the vitality of each organ system.</li>
+                <li>闡述陰陽與五行理論於人體之運用。</li>
+                <li>說明十二經脈氣血運行規律。</li>
+                <li>提出情志、時令與生活方式對臟腑的影響。</li>
             </ul>
         </section>
         <section>
-            <h2>Legacy Note</h2>
-            <p>Qi Bo symbolises the roots of TCM thinking. Practitioners turn to his dialogues whenever they need to reconnect clinical technique with cosmological insight.</p>
+            <h2>後世評述</h2>
+            <p>岐伯象徵中醫思維的源頭，臨床醫者常回到其對話，以連結治法與宇宙自然的關係。</p>
         </section>
-        <footer>Return to the <a href="../index.html">Heritage TCM homepage</a>.</footer>
+        <footer>回到 <a href="../index.html">承古堂首頁</a></footer>
     </main>
 </body>
 </html>

--- a/famous-doctors/sun-simiao.html
+++ b/famous-doctors/sun-simiao.html
@@ -1,49 +1,49 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sun Simiao | Influential TCM Practitioners</title>
-    <meta name="description" content="Biography of Sun Simiao, the King of Medicine and advocate of great doctor compassion.">
+    <title>孫思邈｜影響力中醫名家</title>
+    <meta name="description" content="孫思邈生平與醫道，了解其仁心醫德與《備急千金要方》之貢獻。">
     <link rel="stylesheet" href="../styles.css">
 </head>
 <body class="master-profile">
-    <a class="back-link" href="../famous-tcm-doctors.html">←<span>Back to influential practitioners</span></a>
+    <a class="back-link" href="../famous-tcm-doctors.html">←<span>返回影響力名家列表</span></a>
     <main class="profile-container">
         <header>
-            <h1>Sun Simiao</h1>
-            <p class="profile-tagline">Ethicist and formula master</p>
-            <p class="profile-era">Tang dynasty · 581–682 CE</p>
+            <h1>孫思邈</h1>
+            <p class="profile-tagline">醫德典範與方藥大師</p>
+            <p class="profile-era">唐朝．581–682 年</p>
         </header>
         <section>
-            <h2>Biography</h2>
-            <p>Sun Simiao was a Daoist scholar-physician who lived through multiple dynastic transitions. He believed that a great physician must cultivate virtue equal to skill, writing, “A human life is of the utmost value; nothing is worth more.”</p>
-            <p>His encyclopedic works catalogue emergency care, women’s and children’s health, and detailed lifestyle guidance, pairing classical formulas with lived experience.</p>
+            <h2>生平小傳</h2>
+            <p>孫思邈為道家學者兼醫者，經歷數朝變遷，主張醫者技術須與德性並重，留有「人命至重，有貴千金」的名言。</p>
+            <p>他所著《備急千金要方》及《千金翼方》包羅急救、婦兒與養生指引，將經典方藥與實證經驗融會貫通。</p>
         </section>
         <section>
-            <h2>Clinical Focus</h2>
-            <p>Preventive medicine, comprehensive formularies, and the integration of qigong, dietetics, and moral cultivation.</p>
+            <h2>臨床專長</h2>
+            <p>重視預防醫學、廣納方藥，並結合氣功導引、食療與德行修養。</p>
         </section>
         <section>
-            <h2>Key Contributions</h2>
+            <h2>重要貢獻</h2>
             <ul>
-                <li>Authored <em>Essential Prescriptions Worth a Thousand Gold</em> and its supplement, covering over 5,000 formulas.</li>
-                <li>Outlined ethical guidelines summarised as “Great Doctor, Great Compassion.”</li>
-                <li>Documented smallpox variolation and pioneered public-health thinking centuries before modern immunology.</li>
+                <li>撰成《備急千金要方》與《千金翼方》，收錄五千餘首方藥。</li>
+                <li>提出「大醫精誠」，奠定醫者仁心的倫理準則。</li>
+                <li>記載天花種痘法，具備早期公共衛生視野，遠超其時代。</li>
             </ul>
         </section>
         <section>
-            <h2>Recommended Reading</h2>
+            <h2>延伸閱讀</h2>
             <ul>
-                <li><em>Qianjin Yaofang</em> (Essential Prescriptions Worth a Thousand Gold)</li>
-                <li><em>Qianjin Yifang</em> (Supplement to the Essential Prescriptions)</li>
+                <li><em>備急千金要方</em></li>
+                <li><em>千金翼方</em></li>
             </ul>
         </section>
         <section>
-            <h2>Legacy Note</h2>
-            <p>Sun’s writings remind modern practitioners that clinical excellence rests on humility and service. His emphasis on prevention and daily rituals remains deeply relevant for integrative care.</p>
+            <h2>後世評述</h2>
+            <p>孫思邈著作提醒世人，醫術之精須以謙卑與服務為根基，強調預防與日常養生的觀念，至今仍具指導意義。</p>
         </section>
-        <footer>Return to the <a href="../index.html">Heritage TCM homepage</a>.</footer>
+        <footer>回到 <a href="../index.html">承古堂首頁</a></footer>
     </main>
 </body>
 </html>

--- a/famous-doctors/wang-shuhe.html
+++ b/famous-doctors/wang-shuhe.html
@@ -1,42 +1,42 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Wang Shuhe | Influential TCM Practitioners</title>
-    <meta name="description" content="Biography of Wang Shuhe, compiler of the Pulse Classic and preserver of Zhang Zhongjing’s formulas.">
+    <title>王叔和｜影響力中醫名家</title>
+    <meta name="description" content="王叔和生平與《脈經》要義，了解其守護張仲景方書的功績。">
     <link rel="stylesheet" href="../styles.css">
 </head>
 <body class="master-profile">
-    <a class="back-link" href="../famous-tcm-doctors.html">←<span>Back to influential practitioners</span></a>
+    <a class="back-link" href="../famous-tcm-doctors.html">←<span>返回影響力名家列表</span></a>
     <main class="profile-container">
         <header>
-            <h1>Wang Shuhe</h1>
-            <p class="profile-tagline">Pulse diagnosis specialist</p>
-            <p class="profile-era">Western Jin · ca. 210–286 CE</p>
+            <h1>王叔和</h1>
+            <p class="profile-tagline">脈診專家</p>
+            <p class="profile-era">西晉．約 210–286 年</p>
         </header>
         <section>
-            <h2>Biography</h2>
-            <p>Wang Shuhe served as an imperial physician and devoted himself to the rhythms felt beneath the fingertips. He carefully organised generations of pulse lore, relating qualities to organ systems and seasonal influences.</p>
-            <p>Wang also safeguarded copies of Zhang Zhongjing’s texts at a time when war and fire threatened to erase them.</p>
+            <h2>生平小傳</h2>
+            <p>王叔和曾任太醫，專注於指下脈象之節律，整理歷代脈學，將脈象與臟腑、四時相應。</p>
+            <p>動亂年代，他守護張仲景典籍，使經方得以流傳後世。</p>
         </section>
         <section>
-            <h2>Clinical Focus</h2>
-            <p>Pulse interpretation, classic formula stewardship, and translating theory into everyday diagnostic practice.</p>
+            <h2>臨床專長</h2>
+            <p>精於脈診體察，善於傳承經方，將理論落實於臨床辨證。</p>
         </section>
         <section>
-            <h2>Key Contributions</h2>
+            <h2>重要貢獻</h2>
             <ul>
-                <li>Authored the <em>Maijing</em> (Pulse Classic), categorising twenty-four fundamental pulses.</li>
-                <li>Explained how climate, constitution, and disease alter pulse quality.</li>
-                <li>Ensured the survival of the <em>Shang Han Lun</em> manuscript for future generations.</li>
+                <li>編撰《脈經》，歸納二十四脈綱領。</li>
+                <li>闡述四時、體質與病勢對脈象的影響。</li>
+                <li>保存《傷寒論》手稿，傳承經方脈絡。</li>
             </ul>
         </section>
         <section>
-            <h2>Legacy Note</h2>
-            <p>Modern practitioners still reference Wang’s pulse categories when correlating tactile impressions with internal patterns. His work invites us to slow down and listen to what the blood is saying.</p>
+            <h2>後世評述</h2>
+            <p>今日醫者仍以王氏脈法為依據，將脈下觸感對應內在證候。他提醒我們放慢速度，傾聽血脈的聲音。</p>
         </section>
-        <footer>Return to the <a href="../index.html">Heritage TCM homepage</a>.</footer>
+        <footer>回到 <a href="../index.html">承古堂首頁</a></footer>
     </main>
 </body>
 </html>

--- a/famous-doctors/wu-jutong.html
+++ b/famous-doctors/wu-jutong.html
@@ -1,48 +1,48 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Wu Jutong | Influential TCM Practitioners</title>
-    <meta name="description" content="Biography of Wu Jutong, author of Wen Bing Tiao Bian and warm disease expert.">
+    <title>吳鞠通｜影響力中醫名家</title>
+    <meta name="description" content="吳鞠通生平與《溫病條辨》，理解其完善溫病辨證的貢獻。">
     <link rel="stylesheet" href="../styles.css">
 </head>
 <body class="master-profile">
-    <a class="back-link" href="../famous-tcm-doctors.html">←<span>Back to influential practitioners</span></a>
+    <a class="back-link" href="../famous-tcm-doctors.html">←<span>返回影響力名家列表</span></a>
     <main class="profile-container">
         <header>
-            <h1>Wu Jutong</h1>
-            <p class="profile-tagline">Refiner of warm disease treatment</p>
-            <p class="profile-era">Qing dynasty · 1758–1836 CE</p>
+            <h1>吳鞠通</h1>
+            <p class="profile-tagline">溫病治法完善者</p>
+            <p class="profile-era">清朝．1758–1836 年</p>
         </header>
         <section>
-            <h2>Biography</h2>
-            <p>Wu Jutong studied under Ye Tianshi’s disciples and continued to document epidemic diseases affecting the lower Yangzi region. His notes highlight how heat toxins can lodge in the membrane source, lingering even after fevers fade.</p>
-            <p>He organised these insights into the <em>Wen Bing Tiao Bian</em>, a practical manual for clinicians facing rapidly changing symptoms.</p>
+            <h2>生平小傳</h2>
+            <p>吳鞠通承葉天士弟子之傳，記錄江南地區溫疫流行，指出熱毒易伏於膜原，即使退熱仍可能留戀。</p>
+            <p>他將臨床心得編為《溫病條辨》，提供醫者面對瞬息萬變症勢的實用指南。</p>
         </section>
         <section>
-            <h2>Clinical Focus</h2>
-            <p>Later-stage warm diseases, fluid damage, and complications affecting the pericardium and liver.</p>
+            <h2>臨床專長</h2>
+            <p>專治溫病後期、津傷與波及心包、肝膽的複雜證候。</p>
         </section>
         <section>
-            <h2>Key Contributions</h2>
+            <h2>重要貢獻</h2>
             <ul>
-                <li>Expanded the defensive–qi–nutrient–blood model with clear formula strategies at each stage.</li>
-                <li>Emphasised aromatic, cooling herbs to resolve turbidity lodged between the exterior and interior.</li>
-                <li>Linked lingering pathogens with modern ideas about post-viral syndromes.</li>
+                <li>在衛氣營血架構上，細化各層用方策略。</li>
+                <li>強調芳香清解藥物以化解半表半裡之濁邪。</li>
+                <li>提出伏邪難解的概念，與今日長新冠等後遺症有呼應。</li>
             </ul>
         </section>
         <section>
-            <h2>Recommended Reading</h2>
+            <h2>延伸閱讀</h2>
             <ul>
-                <li><em>Wen Bing Tiao Bian</em> (Systematic Differentiation of Warm Diseases)</li>
+                <li><em>溫病條辨</em></li>
             </ul>
         </section>
         <section>
-            <h2>Legacy Note</h2>
-            <p>Wu’s formulations—such as Yin Qiao San and Qing Ying Tang—remain staples in clinics worldwide. His work bridges classical insights with the challenges of emerging infectious disease.</p>
+            <h2>後世評述</h2>
+            <p>吳氏創製的銀翹散、清營湯等方仍廣為應用，其著作讓傳統智慧與新興疫病的挑戰得以銜接。</p>
         </section>
-        <footer>Return to the <a href="../index.html">Heritage TCM homepage</a>.</footer>
+        <footer>回到 <a href="../index.html">承古堂首頁</a></footer>
     </main>
 </body>
 </html>

--- a/famous-doctors/ye-tianshi.html
+++ b/famous-doctors/ye-tianshi.html
@@ -1,48 +1,48 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Ye Tianshi | Influential TCM Practitioners</title>
-    <meta name="description" content="Biography of Ye Tianshi, architect of the warm disease defensive-qi-nutrient-blood model.">
+    <title>葉天士｜影響力中醫名家</title>
+    <meta name="description" content="葉天士生平與衛氣營血辨證，了解其溫病學的重要地位。">
     <link rel="stylesheet" href="../styles.css">
 </head>
 <body class="master-profile">
-    <a class="back-link" href="../famous-tcm-doctors.html">←<span>Back to influential practitioners</span></a>
+    <a class="back-link" href="../famous-tcm-doctors.html">←<span>返回影響力名家列表</span></a>
     <main class="profile-container">
         <header>
-            <h1>Ye Tianshi</h1>
-            <p class="profile-tagline">Warm disease strategist</p>
-            <p class="profile-era">Qing dynasty · 1667–1746 CE</p>
+            <h1>葉天士</h1>
+            <p class="profile-tagline">溫病辨證大師</p>
+            <p class="profile-era">清朝．1667–1746 年</p>
         </header>
         <section>
-            <h2>Biography</h2>
-            <p>Ye Tianshi lived in an era when epidemic fevers were increasingly common. He recognised that these warm pathogens behaved differently from cold-induced disorders and required a new diagnostic map.</p>
-            <p>His patients ranged from emperors to ordinary citizens, and he chronicled their responses to herbal interventions with meticulous clarity.</p>
+            <h2>生平小傳</h2>
+            <p>葉天士所處年代，溫熱疫病頻繁，他洞見此類外邪有別於寒邪，需建立全新辨證架構。</p>
+            <p>其醫案涵蓋皇室與民間，詳細記錄方藥應用與病勢轉變，文字精密。</p>
         </section>
         <section>
-            <h2>Clinical Focus</h2>
-            <p>High fevers, febrile contagions, and the lingering aftermath of heat diseases.</p>
+            <h2>臨床專長</h2>
+            <p>處理高熱疫癘、溫病傳變及熱病後遺症。</p>
         </section>
         <section>
-            <h2>Key Contributions</h2>
+            <h2>重要貢獻</h2>
             <ul>
-                <li>Introduced the defensive–qi–nutrient–blood stages, tracing how heat moves deeper into the body.</li>
-                <li>Recommended lighter, aromatic herbs to vent heat through the upper burner in early stages.</li>
-                <li>Showed how fluids can be preserved while clearing toxicity.</li>
+                <li>創立衛、氣、營、血四層辨證，描繪熱邪入裡路徑。</li>
+                <li>強調初期以芳香輕透之品宣泄上焦熱邪。</li>
+                <li>提出清熱同時顧護津液的治則。</li>
             </ul>
         </section>
         <section>
-            <h2>Recommended Reading</h2>
+            <h2>延伸閱讀</h2>
             <ul>
-                <li><em>Wen Re Lun</em> (Treatise on Warm Heat Diseases)</li>
+                <li><em>溫熱論</em></li>
             </ul>
         </section>
         <section>
-            <h2>Legacy Note</h2>
-            <p>Ye Tianshi’s framework remains a cornerstone for clinicians managing viral infections, heat stroke, and inflammatory flare-ups. His emphasis on stage-appropriate herbs informs modern integrative care.</p>
+            <h2>後世評述</h2>
+            <p>葉氏辨證體系仍是應對病毒感染、暑熱與炎症加劇的重要依據，他強調隨證選藥的思路對今日整合醫療深具啟發。</p>
         </section>
-        <footer>Return to the <a href="../index.html">Heritage TCM homepage</a>.</footer>
+        <footer>回到 <a href="../index.html">承古堂首頁</a></footer>
     </main>
 </body>
 </html>

--- a/famous-doctors/zhang-zhongjing.html
+++ b/famous-doctors/zhang-zhongjing.html
@@ -1,49 +1,49 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Zhang Zhongjing | Influential TCM Practitioners</title>
-    <meta name="description" content="Biography of Zhang Zhongjing, the Sage of Medicine and author of the Shang Han Lun and Jinkui Yaolue.">
+    <title>張仲景｜影響力中醫名家</title>
+    <meta name="description" content="張仲景生平與學術重點，了解《傷寒論》《金匱要略》如何奠定經方辨證體系。">
     <link rel="stylesheet" href="../styles.css">
 </head>
 <body class="master-profile">
-    <a class="back-link" href="../famous-tcm-doctors.html">←<span>Back to influential practitioners</span></a>
+    <a class="back-link" href="../famous-tcm-doctors.html">←<span>返回影響力名家列表</span></a>
     <main class="profile-container">
         <header>
-            <h1>Zhang Zhongjing</h1>
-            <p class="profile-tagline">Author of the <em>Shang Han Lun</em></p>
-            <p class="profile-era">Eastern Han · ca. 150–219 CE</p>
+            <h1>張仲景</h1>
+            <p class="profile-tagline">《傷寒論》與《金匱要略》作者</p>
+            <p class="profile-era">東漢．約 150–219 年</p>
         </header>
         <section>
-            <h2>Biography</h2>
-            <p>Zhang Zhongjing, courtesy name Jing, distilled centuries of medical learning into a cohesive clinical method. As epidemics ravaged the Eastern Han dynasty, he compiled insights from mentors and peers, seeking formulas that could be adapted as exterior conditions penetrated into the body.</p>
-            <p>His approach blends observation, pulse diagnosis, and the dynamic tracking of cold-induced disorders. He is celebrated as the “Sage of Medicine” whose clarity still guides clinicians today.</p>
+            <h2>生平小傳</h2>
+            <p>張仲景，字機，綜攝先秦至漢代醫學精華，建構嚴謹的臨床辨證體系。東漢疫癘頻仍，他廣納師友所傳方論，整理出可隨病勢深入而靈活調整的經方架構。</p>
+            <p>其診療重視望聞問切與脈象變化，洞悉寒邪由表入裡的節奏，被後世尊稱為「醫聖」，影響綿延至今。</p>
         </section>
         <section>
-            <h2>Clinical Focus</h2>
-            <p>Systematic pattern differentiation across the six conformations, precise formula selection, and flexible additions that respond to change without violating classical principles.</p>
+            <h2>臨床專長</h2>
+            <p>以六經辨證為綱，依證配方，並能於不違經旨下加減藥味，因應病勢轉化。</p>
         </section>
         <section>
-            <h2>Key Contributions</h2>
+            <h2>重要貢獻</h2>
             <ul>
-                <li>Codified the six conformation framework that maps the progression of externally contracted disease.</li>
-                <li>Preserved more than one hundred classical formulas, complete with indications, ingredients, and dosages.</li>
-                <li>Advanced the idea of “pattern first, disease name second,” inspiring centuries of formula-based practice.</li>
+                <li>建立六經辨證架構，描繪外感病由表入裡的傳變途徑。</li>
+                <li>保存百餘首經方，詳列主治、藥味與劑量，利於臨床遵循。</li>
+                <li>提倡「辨證論治」理念，重視證候而非病名，奠定方證相對的核心精神。</li>
             </ul>
         </section>
         <section>
-            <h2>Recommended Reading</h2>
+            <h2>延伸閱讀</h2>
             <ul>
-                <li><em>Shang Han Lun</em> (Treatise on Cold Damage)</li>
-                <li><em>Jinkui Yaolue</em> (Essential Prescriptions of the Golden Coffer)</li>
+                <li><em>傷寒論</em></li>
+                <li><em>金匱要略</em></li>
             </ul>
         </section>
         <section>
-            <h2>Legacy Note</h2>
-            <p>Zhang’s work reminds practitioners to look beyond symptoms toward the underlying momentum of illness. Each formula is a snapshot of how qi and fluids are moving, encouraging thoughtful adjustment rather than rote prescription.</p>
+            <h2>後世評述</h2>
+            <p>張氏著作提醒醫者觀察病勢流轉的方向，方藥如同氣血運行的剪影，需以活法調整，而非拘泥成方。</p>
         </section>
-        <footer>Return to the <a href="../index.html">Heritage TCM homepage</a>.</footer>
+        <footer>回到 <a href="../index.html">承古堂首頁</a></footer>
     </main>
 </body>
 </html>

--- a/famous-doctors/zhu-danxi.html
+++ b/famous-doctors/zhu-danxi.html
@@ -1,48 +1,48 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Zhu Danxi | Influential TCM Practitioners</title>
-    <meta name="description" content="Biography of Zhu Danxi, advocate of nourishing yin and moderating fire in Traditional Chinese Medicine.">
+    <title>朱丹溪｜影響力中醫名家</title>
+    <meta name="description" content="朱丹溪生平與養陰降火學說，了解其對陰虛內熱證的見解。">
     <link rel="stylesheet" href="../styles.css">
 </head>
 <body class="master-profile">
-    <a class="back-link" href="../famous-tcm-doctors.html">←<span>Back to influential practitioners</span></a>
+    <a class="back-link" href="../famous-tcm-doctors.html">←<span>返回影響力名家列表</span></a>
     <main class="profile-container">
         <header>
-            <h1>Zhu Danxi</h1>
-            <p class="profile-tagline">Nourish yin, restrain fire</p>
-            <p class="profile-era">Yuan dynasty · 1281–1358 CE</p>
+            <h1>朱丹溪</h1>
+            <p class="profile-tagline">養陰降火</p>
+            <p class="profile-era">元朝．1281–1358 年</p>
         </header>
         <section>
-            <h2>Biography</h2>
-            <p>Zhu Danxi, also known as Zhu Zhenheng, observed that the stresses of literati life—late nights, rich food, emotional intensity—tended to deplete yin and stir internal fire. He argued that most people had “yang in surplus and yin in deficiency.”</p>
-            <p>His prescriptions therefore emphasise moistening, cooling, and directing the ministerial fire downward.</p>
+            <h2>生平小傳</h2>
+            <p>朱丹溪，名震亨，洞察士人生活多夜寐、厚味、情志鬱結，易致陰津虧損、相火內擾，提出「陽常有餘，陰常不足」。</p>
+            <p>因此用藥多滋陰養液、清降相火，使陰陽重歸平衡。</p>
         </section>
         <section>
-            <h2>Clinical Focus</h2>
-            <p>Women’s health, emotional regulation, and chronic inflammatory conditions marked by yin deficiency heat.</p>
+            <h2>臨床專長</h2>
+            <p>擅治婦科、情志失調與陰虛內熱所致的慢性炎症。</p>
         </section>
         <section>
-            <h2>Key Contributions</h2>
+            <h2>重要貢獻</h2>
             <ul>
-                <li>Promoted the idea that quiet cultivation and diet are essential allies to herbal therapy.</li>
-                <li>Created formulas such as Zhi Bai Di Huang Wan to clear heat while nourishing fluids.</li>
-                <li>Balanced the tonifying strategies of his contemporaries with gentle restraint.</li>
+                <li>強調靜養與飲食節制為藥物療法的助手。</li>
+                <li>創制知柏地黃丸等方，以清熱養陰兼顧。</li>
+                <li>調和當時偏於溫補的思路，以滋陰制火為其特色。</li>
             </ul>
         </section>
         <section>
-            <h2>Recommended Reading</h2>
+            <h2>延伸閱讀</h2>
             <ul>
-                <li><em>Gezhi Yulun</em> (Words of Discourse on Knowledge)</li>
+                <li><em>格致餘論</em></li>
             </ul>
         </section>
         <section>
-            <h2>Legacy Note</h2>
-            <p>Zhu’s reminder that lifestyle shapes our internal fire resonates today. His yin-nourishing formulas remain central for perimenopausal transition, stress-related insomnia, and skin flare-ups.</p>
+            <h2>後世評述</h2>
+            <p>朱氏提醒人們生活習慣會左右內火，他的養陰降火方至今仍廣用於更年期調理、壓力性失眠與肌膚火熱問題。</p>
         </section>
-        <footer>Return to the <a href="../index.html">Heritage TCM homepage</a>.</footer>
+        <footer>回到 <a href="../index.html">承古堂首頁</a></footer>
     </main>
 </body>
 </html>

--- a/famous-tcm-doctors.html
+++ b/famous-tcm-doctors.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Influential TCM Practitioners</title>
-    <meta name="description" content="Meet trailblazing Traditional Chinese Medicine physicians whose ideas still shape modern clinical practice.">
+    <title>影響力中醫名家</title>
+    <meta name="description" content="認識歷代重要中醫醫家，了解他們的學術思想如何持續影響今日臨床。">
     <link rel="stylesheet" href="styles.css">
     <style>
         body { font-family: 'Noto Sans', 'Helvetica Neue', Arial, sans-serif; background: #f5f7fa; color: #2c3e50; }
@@ -26,83 +26,83 @@
 </head>
 <body>
     <div class="container">
-        <h1>Influential TCM Practitioners</h1>
-        <p class="description">From legendary physicians of antiquity to twentieth-century reformers, these practitioners helped shape the art of pattern differentiation and herbal prescribing.</p>
+        <h1>影響力中醫名家</h1>
+        <p class="description">從古代醫聖到近代改革者，他們奠定辨證論治與方藥應用的根基，照耀今日臨床。</p>
         <div class="masters-grid">
             <article class="master-card">
-                <h2>Zhang Zhongjing</h2>
-                <div class="era">Eastern Han · ca. 150–219 CE</div>
-                <p>The “Sage of Medicine” whose <em>Shang Han Lun</em> and <em>Jinkui Yaolue</em> codified the six conformations and the idea that each pattern deserves its own formula.</p>
-                <a href="famous-doctors/zhang-zhongjing.html" aria-label="Read more about Zhang Zhongjing">Read profile<span>→</span></a>
+                <h2>張仲景</h2>
+                <div class="era">東漢．約 150–219 年</div>
+                <p>被尊為「醫聖」，著有《傷寒論》《金匱要略》，確立六經辨證與方證對應，影響深遠。</p>
+                <a href="famous-doctors/zhang-zhongjing.html" aria-label="閱讀張仲景介紹">閱讀全文<span>→</span></a>
             </article>
             <article class="master-card">
-                <h2>Sun Simiao</h2>
-                <div class="era">Tang dynasty · 581–682 CE</div>
-                <p>Known as the “King of Medicine,” Sun championed compassionate ethics, preventive care, and extensive formularies in his <em>Essential Prescriptions Worth a Thousand Gold</em>.</p>
-                <a href="famous-doctors/sun-simiao.html" aria-label="Read more about Sun Simiao">Read profile<span>→</span></a>
+                <h2>孫思邈</h2>
+                <div class="era">唐朝．581–682 年</div>
+                <p>享有「藥王」美譽，著《備急千金要方》，倡導醫者仁心與預防保健，方藥廣博。</p>
+                <a href="famous-doctors/sun-simiao.html" aria-label="閱讀孫思邈介紹">閱讀全文<span>→</span></a>
             </article>
             <article class="master-card">
-                <h2>Li Shizhen</h2>
-                <div class="era">Ming dynasty · 1518–1593 CE</div>
-                <p>A meticulous field researcher whose <em>Compendium of Materia Medica</em> corrected errors and added hundreds of herbs, becoming the cornerstone of herbal scholarship.</p>
-                <a href="famous-doctors/li-shizhen.html" aria-label="Read more about Li Shizhen">Read profile<span>→</span></a>
+                <h2>李時珍</h2>
+                <div class="era">明朝．1518–1593 年</div>
+                <p>遍訪民間採藥，撰成《本草綱目》，訂正舊說並增補諸多藥材，被譽為本草集大成。</p>
+                <a href="famous-doctors/li-shizhen.html" aria-label="閱讀李時珍介紹">閱讀全文<span>→</span></a>
             </article>
             <article class="master-card">
-                <h2>Hua Tuo</h2>
-                <div class="era">Late Eastern Han · ca. 145–208 CE</div>
-                <p>Surgical pioneer and creator of the Five Animal Frolics exercises, Hua Tuo is celebrated for anaesthetic innovation and agile, whole-body training.</p>
-                <a href="famous-doctors/hua-tuo.html" aria-label="Read more about Hua Tuo">Read profile<span>→</span></a>
+                <h2>華佗</h2>
+                <div class="era">東漢晚期．約 145–208 年</div>
+                <p>擅長外科手術與麻沸散之創制，並創五禽戲導引功，強調身心靈活鍛鍊。</p>
+                <a href="famous-doctors/hua-tuo.html" aria-label="閱讀華佗介紹">閱讀全文<span>→</span></a>
             </article>
             <article class="master-card">
-                <h2>Bian Que</h2>
-                <div class="era">Warring States · ca. 407–310 BCE</div>
-                <p>A master diagnostician whose four examinations—looking, listening, asking, and palpating—became the standard for identifying patterns before they progress.</p>
-                <a href="famous-doctors/bian-que.html" aria-label="Read more about Bian Que">Read profile<span>→</span></a>
+                <h2>扁鵲</h2>
+                <div class="era">戰國．約前 407–310 年</div>
+                <p>診斷名家，善用望聞問切四診，強調未病先防，奠定辨證基礎。</p>
+                <a href="famous-doctors/bian-que.html" aria-label="閱讀扁鵲介紹">閱讀全文<span>→</span></a>
             </article>
             <article class="master-card">
-                <h2>Wang Shuhe</h2>
-                <div class="era">Western Jin · ca. 210–286 CE</div>
-                <p>Compiled the <em>Pulse Classic</em> and preserved Zhang Zhongjing’s formulas, cementing pulse diagnosis as a diagnostic art.</p>
-                <a href="famous-doctors/wang-shuhe.html" aria-label="Read more about Wang Shuhe">Read profile<span>→</span></a>
+                <h2>王叔和</h2>
+                <div class="era">西晉．約 210–286 年</div>
+                <p>編纂《脈經》，整理仲景方書，使脈診成為精細辨證的藝術。</p>
+                <a href="famous-doctors/wang-shuhe.html" aria-label="閱讀王叔和介紹">閱讀全文<span>→</span></a>
             </article>
             <article class="master-card">
-                <h2>Li Dongyuan</h2>
-                <div class="era">Jin dynasty · 1180–1251 CE</div>
-                <p>Founder of the Spleen and Stomach school who emphasised nourishing earth to treat chronic fatigue, digestive issues, and lingering dampness.</p>
-                <a href="famous-doctors/li-dongyuan.html" aria-label="Read more about Li Dongyuan">Read profile<span>→</span></a>
+                <h2>李東垣</h2>
+                <div class="era">金朝．1180–1251 年</div>
+                <p>脾胃學派創立者，主張補土派，強調培補後天以治勞倦、脾虛與濕困。</p>
+                <a href="famous-doctors/li-dongyuan.html" aria-label="閱讀李東垣介紹">閱讀全文<span>→</span></a>
             </article>
             <article class="master-card">
-                <h2>Zhu Danxi</h2>
-                <div class="era">Yuan dynasty · 1281–1358 CE</div>
-                <p>A champion of nourishing yin and clearing ministerial fire, offering balance to the hotter prescriptions of his era.</p>
-                <a href="famous-doctors/zhu-danxi.html" aria-label="Read more about Zhu Danxi">Read profile<span>→</span></a>
+                <h2>朱丹溪</h2>
+                <div class="era">元朝．1281–1358 年</div>
+                <p>養陰派代表，提出「陽常有餘，陰常不足」，善於清相火、滋陰降火，以平衡偏熱治法。</p>
+                <a href="famous-doctors/zhu-danxi.html" aria-label="閱讀朱丹溪介紹">閱讀全文<span>→</span></a>
             </article>
             <article class="master-card">
-                <h2>Ye Tianshi</h2>
-                <div class="era">Qing dynasty · 1667–1746 CE</div>
-                <p>Warm disease specialist who articulated the defensive–qi–nutrient–blood model, shaping how febrile illnesses are treated today.</p>
-                <a href="famous-doctors/ye-tianshi.html" aria-label="Read more about Ye Tianshi">Read profile<span>→</span></a>
+                <h2>葉天士</h2>
+                <div class="era">清朝．1667–1746 年</div>
+                <p>溫病學大師，提出衛氣營血辨證，開創熱病分層治療的新格局。</p>
+                <a href="famous-doctors/ye-tianshi.html" aria-label="閱讀葉天士介紹">閱讀全文<span>→</span></a>
             </article>
             <article class="master-card">
-                <h2>Wu Jutong</h2>
-                <div class="era">Qing dynasty · 1758–1836 CE</div>
-                <p>Successor to the warm disease lineage whose <em>Wen Bing Tiao Bian</em> provides precise herbal strategies for progressive heat disorders.</p>
-                <a href="famous-doctors/wu-jutong.html" aria-label="Read more about Wu Jutong">Read profile<span>→</span></a>
+                <h2>吳鞠通</h2>
+                <div class="era">清朝．1758–1836 年</div>
+                <p>承接溫病學脈絡，著《溫病條辨》，細緻分證施治，對熱病療法影響深遠。</p>
+                <a href="famous-doctors/wu-jutong.html" aria-label="閱讀吳鞠通介紹">閱讀全文<span>→</span></a>
             </article>
             <article class="master-card">
-                <h2>Qi Bo</h2>
-                <div class="era">Mythic antiquity</div>
-                <p>The legendary imperial physician in the <em>Huangdi Neijing</em>, offering dialogues on seasonal living, meridian theory, and preventive care.</p>
-                <a href="famous-doctors/qi-bo.html" aria-label="Read more about Qi Bo">Read profile<span>→</span></a>
+                <h2>岐伯</h2>
+                <div class="era">上古傳說</div>
+                <p>《黃帝內經》中的傳說御醫，與黃帝論道四時養生、經絡學說與預防醫學。</p>
+                <a href="famous-doctors/qi-bo.html" aria-label="閱讀岐伯介紹">閱讀全文<span>→</span></a>
             </article>
             <article class="master-card">
-                <h2>Ni Hai-Xia</h2>
-                <div class="era">Contemporary · 1954–2012 CE</div>
-                <p>An inspirational teacher who brought classical formulas to English-speaking audiences, emphasising astronomy, channel theory, and compassionate clinical practice.</p>
-                <a href="famous-doctors/ni-haixia.html" aria-label="Read more about Ni Hai-Xia">Read profile<span>→</span></a>
+                <h2>倪海廈</h2>
+                <div class="era">當代．1954–2012 年</div>
+                <p>推廣經方於華語與英語世界，融會天文、經絡與仁心醫道，啟發無數後學。</p>
+                <a href="famous-doctors/ni-haixia.html" aria-label="閱讀倪海廈介紹">閱讀全文<span>→</span></a>
             </article>
         </div>
-        <footer>Return to the <a href="index.html">Heritage TCM homepage</a>.</footer>
+        <footer>回到 <a href="index.html">承古堂首頁</a></footer>
     </div>
 </body>
 </html>

--- a/food-nutrition.html
+++ b/food-nutrition.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TCM-Inspired Nutrition | Heritage TCM</title>
-    <meta name="description" content="Seasonal meal ideas, warming and cooling ingredients, and breakfast pairings inspired by Traditional Chinese Medicine.">
+    <title>中醫飲食指南｜承古堂</title>
+    <meta name="description" content="以傳統中醫為靈感的當令餐點、溫涼食材與早餐搭配建議。">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 </head>
@@ -13,12 +13,12 @@
         <div class="nav-container">
             <div class="nav-logo">
                 <i class="fas fa-leaf"></i>
-                <span>Heritage TCM</span>
+                <span>承古堂</span>
             </div>
             <ul class="nav-menu">
-                <li class="nav-item"><a href="index.html" class="nav-link">Home</a></li>
-                <li class="nav-item"><a href="food-nutrition.html" class="nav-link active">TCM Nutrition</a></li>
-                <li class="nav-item"><a href="zhongyao.html" class="nav-link">Herbal Library</a></li>
+                <li class="nav-item"><a href="index.html" class="nav-link">首頁</a></li>
+                <li class="nav-item"><a href="food-nutrition.html" class="nav-link active">中醫飲食</a></li>
+                <li class="nav-item"><a href="zhongyao.html" class="nav-link">本草庫</a></li>
             </ul>
         </div>
     </nav>
@@ -26,9 +26,9 @@
     <main class="nutrition-page">
         <header class="nutrition-header">
             <div class="container">
-                <p class="section-eyebrow">Daily nourishment</p>
-                <h1>TCM-Inspired Nutrition Planner</h1>
-                <p class="section-subtitle">Build balanced meals with whole foods that align with your constitution and the season.</p>
+                <p class="section-eyebrow">每日滋養</p>
+                <h1>中醫飲食規畫</h1>
+                <p class="section-subtitle">以四時、體質為本，運用天然食材搭配出和諧的一日餐表。</p>
             </div>
         </header>
 
@@ -36,58 +36,58 @@
             <div class="container nutrition-layout">
                 <div class="food-panel">
                     <div class="panel-header">
-                        <h2>Breakfast pairings</h2>
+                        <h2>早餐搭配</h2>
                     </div>
                     <div class="food-grid nutrition-cards">
                         <article class="nutrition-card">
-                            <h3>Oats + Goji + Walnut</h3>
-                            <p>Builds spleen qi and nourishes the blood. Add cinnamon if mornings feel chilly.</p>
+                            <h3>燕麥＋枸杞＋核桃</h3>
+                            <p>健脾益氣、養血明目，晨間怕冷者可加肉桂增溫。</p>
                             <ul>
-                                <li>Approx. 320 kcal</li>
-                                <li>Plant protein · Omega-3 fats · Fibre</li>
+                                <li>熱量約 320 kcal</li>
+                                <li>植物蛋白・Omega-3・膳食纖維</li>
                             </ul>
                         </article>
                         <article class="nutrition-card">
-                            <h3>Millet Congee + Pear</h3>
-                            <p>Moistens dryness and soothes digestion—ideal for late summer and early autumn.</p>
+                            <h3>小米粥＋梨子</h3>
+                            <p>潤燥養胃，適合長夏至初秋調理脾胃。</p>
                             <ul>
-                                <li>Approx. 280 kcal</li>
-                                <li>Cooling, gentle on the stomach</li>
+                                <li>熱量約 280 kcal</li>
+                                <li>性味清潤，溫和順胃</li>
                             </ul>
                         </article>
                         <article class="nutrition-card">
-                            <h3>Egg + Steamed Greens</h3>
-                            <p>Supports liver blood and keeps energy steady for busy mornings.</p>
+                            <h3>水煮蛋＋蒸青菜</h3>
+                            <p>養肝血、穩定氣力，應付繁忙早晨。</p>
                             <ul>
-                                <li>Approx. 300 kcal</li>
-                                <li>High-quality protein · Folate · Iron</li>
+                                <li>熱量約 300 kcal</li>
+                                <li>優質蛋白・葉酸・鐵質</li>
                             </ul>
                         </article>
                     </div>
                 </div>
 
                 <div class="analysis-panel nutrition-guidance">
-                    <h2>Seasonal guidance</h2>
+                    <h2>四時食養</h2>
                     <div class="season-grid">
                         <article>
-                            <h3>Spring · Wood element</h3>
-                            <p>Focus on lightly cooked greens, sprouts, and sour flavours. Sip chrysanthemum tea to cool rising yang.</p>
+                            <h3>春季・木</h3>
+                            <p>多食清炒綠葉、芽菜與酸味，搭配菊花茶柔和升陽。</p>
                         </article>
                         <article>
-                            <h3>Summer · Fire element</h3>
-                            <p>Hydrate with watermelon, cucumber, and mung bean soup. Keep cooking methods quick to preserve vitality.</p>
+                            <h3>夏季・火</h3>
+                            <p>以西瓜、黃瓜、綠豆湯補水降溫，烹調宜快火輕煮保留鮮活。</p>
                         </article>
                         <article>
-                            <h3>Late Summer · Earth element</h3>
-                            <p>Support the spleen with millet, sweet potato, and adzuki bean soups. Avoid excessive cold drinks.</p>
+                            <h3>長夏・土</h3>
+                            <p>以小米、地瓜與紅豆湯健脾祛濕，少飲冰品。</p>
                         </article>
                         <article>
-                            <h3>Autumn · Metal element</h3>
-                            <p>Moisten lung yin with pear, lily bulb, sesame, and honey. Add ginger to dispel wind chill.</p>
+                            <h3>秋季・金</h3>
+                            <p>梨、百合、芝麻、蜂蜜可潤肺陰，佐薑驅風寒。</p>
                         </article>
                         <article>
-                            <h3>Winter · Water element</h3>
-                            <p>Warm the kidneys with black beans, lamb broth, and cinnamon-spiced teas. Emphasise hearty stews.</p>
+                            <h3>冬季・水</h3>
+                            <p>黑豆、羊肉湯與肉桂茶溫補腎陽，料理以燉煮為主。</p>
                         </article>
                     </div>
                 </div>
@@ -97,22 +97,22 @@
         <section class="nutrition-tips">
             <div class="container">
                 <div class="section-header">
-                    <p class="section-eyebrow">Quick tips</p>
-                    <h2 class="section-title">Make every meal count</h2>
-                    <p class="section-subtitle">Small shifts can align your diet with TCM principles.</p>
+                    <p class="section-eyebrow">即刻行動</p>
+                    <h2 class="section-title">讓每餐更貼心</h2>
+                    <p class="section-subtitle">微調飲食節奏，就能貼近中醫養生。</p>
                 </div>
                 <div class="tips-grid">
                     <article>
-                        <h3>Balance temperature</h3>
-                        <p>Pair warming ingredients (ginger, cinnamon, lamb) with cooling ones (pear, cucumber, tofu) to suit your internal climate.</p>
+                        <h3>溫涼調和</h3>
+                        <p>薑、桂、羊肉等溫性食材，可與梨、黃瓜、豆腐等清潤食物搭配，隨體質調節寒熱。</p>
                     </article>
                     <article>
-                        <h3>Favour whole grains</h3>
-                        <p>Switch refined carbs for millet, barley, or brown rice to stabilise qi and nourish the spleen.</p>
+                        <h3>多選全穀</h3>
+                        <p>以小米、大麥、糙米取代精緻澱粉，扶助脾氣運化。</p>
                     </article>
                     <article>
-                        <h3>Eat with the clock</h3>
-                        <p>Enjoy the largest meal at midday when digestive fire peaks; keep dinners lighter to support sleep.</p>
+                        <h3>順時而食</h3>
+                        <p>午時陽氣最盛，可安排主餐；晚餐宜清淡，助眠養心。</p>
                     </article>
                 </div>
             </div>
@@ -123,19 +123,19 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-section">
-                    <h3>Heritage TCM</h3>
-                    <p>Classical wisdom, practical nourishment.</p>
+                    <h3>承古堂</h3>
+                    <p>以經典智慧指引實用飲食。</p>
                 </div>
                 <div class="footer-section">
-                    <h4>Quick Links</h4>
+                    <h4>快速連結</h4>
                     <ul>
-                        <li><a href="index.html#home">Home</a></li>
-                        <li><a href="famous-tcm-doctors.html">Practitioners</a></li>
-                        <li><a href="zhongyao.html">Herbal Library</a></li>
+                        <li><a href="index.html#home">首頁</a></li>
+                        <li><a href="famous-tcm-doctors.html">名醫薈萃</a></li>
+                        <li><a href="zhongyao.html">本草庫</a></li>
                     </ul>
                 </div>
                 <div class="footer-section">
-                    <h4>Contact</h4>
+                    <h4>聯絡資訊</h4>
                     <ul>
                         <li><i class="fas fa-envelope"></i> hello@heritagetcm.com</li>
                         <li><i class="fas fa-phone"></i> +1-407-555-1688</li>
@@ -143,7 +143,7 @@
                 </div>
             </div>
             <div class="footer-bottom">
-                <p>&copy; 2024 Heritage TCM. All rights reserved.</p>
+                <p>&copy; 2024 承古堂。保留所有權利。</p>
             </div>
         </div>
     </footer>

--- a/homepage-herbs.js
+++ b/homepage-herbs.js
@@ -3,9 +3,9 @@ import shennongHerbs from './data/shennong-herbs.js';
 const PAGE_SIZE = 6;
 
 const gradeLabels = {
-  Superior: 'Superior class',
-  Medium: 'Middle class',
-  Regular: 'Lower class'
+  Superior: '上品',
+  Medium: '中品',
+  Regular: '下品'
 };
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -37,14 +37,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const updateCounter = (filteredCount, totalPages) => {
     if (!counterEl) return;
     if (!filteredCount) {
-      counterEl.textContent = 'No matching herbs yet';
+      counterEl.textContent = '尚無符合條件的藥味';
       return;
     }
 
     const base = keyword
-      ? `${filteredCount} herbs match your search`
-      : `${totalCount} classical herbs available`;
-    counterEl.textContent = `${base} · Page ${currentPage} of ${totalPages}`;
+      ? `共有 ${filteredCount} 味藥符合搜尋`
+      : `館藏 ${totalCount} 味本草`;
+    counterEl.textContent = `${base} · 第 ${currentPage} / ${totalPages} 頁`;
   };
 
   const createHerbCard = herb => {
@@ -81,7 +81,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const summary = document.createElement('p');
     summary.className = 'herb-card__summary';
-    summary.textContent = herb.classicalText.split('. ')[0] || herb.classicalText;
+    const summaryText = herb.classicalText.includes('。')
+      ? herb.classicalText.split('。')[0]
+      : herb.classicalText.split('. ')[0];
+    summary.textContent = summaryText || herb.classicalText;
 
     const classic = document.createElement('p');
     classic.className = 'herb-classic';
@@ -137,17 +140,17 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
-    paginationEl.appendChild(createButton('Prev', currentPage - 1, currentPage === 1, 'Previous page'));
+    paginationEl.appendChild(createButton('上一頁', currentPage - 1, currentPage === 1, '前往上一頁'));
 
     for (let page = 1; page <= totalPages; page += 1) {
-      const btn = createButton(String(page), page, false, `Go to page ${page}`);
+      const btn = createButton(String(page), page, false, `跳至第 ${page} 頁`);
       if (page === currentPage) {
         btn.classList.add('is-active');
       }
       paginationEl.appendChild(btn);
     }
 
-    paginationEl.appendChild(createButton('Next', currentPage + 1, currentPage === totalPages, 'Next page'));
+    paginationEl.appendChild(createButton('下一頁', currentPage + 1, currentPage === totalPages, '前往下一頁'));
   };
 
   if (searchInput) {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -14,13 +14,13 @@
   gtag('config', 'G-EHN79KD4GP');
 </script>
     <!-- SEO Meta Tags -->
-    <title>Traditional Chinese Medicine Clinic | Holistic TCM Care & Learning</title>
-    <meta name="description" content="English-language hub for authentic Traditional Chinese Medicine. Discover herbal formulas, classical theory, trusted practitioners, nutrition tips, and ways to weave TCM into modern life.">
-    <meta name="keywords" content="Traditional Chinese Medicine, TCM clinic, herbal medicine, acupuncture, TCM nutrition, classical formulas, Zhang Zhongjing, Huangdi Neijing, holistic health, herbal apothecary, wellness, preventive care">
+    <title>傳統中醫館｜全方位中醫照護與學習</title>
+    <meta name="description" content="正宗中醫資訊匯聚於此，精選方藥、經典理論、名家醫案、食療養生與現代生活調攝，幫助您以傳統智慧滋養日常。">
+    <meta name="keywords" content="傳統中醫, 中醫診所, 中藥, 針灸, 中醫食療, 經方, 張仲景, 黃帝內經, 養生, 草本藥材, 預防保健">
 
     <!-- Open Graph Meta Tags -->
-    <meta property="og:title" content="Traditional Chinese Medicine Clinic | Holistic TCM Care & Learning">
-    <meta property="og:description" content="Explore trusted English-language guides to herbal medicine, classical theory, seasoned practitioners, and nourishing lifestyle practices.">
+    <meta property="og:title" content="傳統中醫館｜全方位中醫照護與學習">
+    <meta property="og:description" content="深度探索經典本草、臨床心得與養生日常，傳承兩千年中醫智慧。">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://traditionalchinesemedicine.online">
     <meta property="og:image" content="https://images.unsplash.com/photo-1501785888041-af3ef285b470?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80">
@@ -49,9 +49,9 @@
     {
         "@context": "https://schema.org",
         "@type": "MedicalClinic",
-        "name": "Heritage TCM Collective",
-        "alternateName": "Traditional Chinese Medicine Clinic",
-        "description": "English guidance on classical herbal formulas, acupuncture-inspired lifestyle care, and practitioner consultations.",
+        "name": "承古堂中醫聯盟",
+        "alternateName": "傳統中醫館",
+        "description": "以繁體中文分享經典方藥、針灸養生與診療服務，提供專業諮詢與自我調攝指引。",
         "url": "https://traditionalchinesemedicine.online",
         "telephone": "+1-407-555-1688",
         "address": {
@@ -62,14 +62,14 @@
         },
         "medicalSpecialty": "Traditional Chinese Medicine",
         "availableService": [
-            "Classical formula consultations",
-            "Herbal therapy",
-            "Lifestyle and nutrition coaching",
-            "TCM education workshops",
-            "Virtual follow-up visits",
-            "Sleep support plans",
-            "Metabolic wellness programs",
-            "Stress and mood balancing"
+            "經方處方與調整",
+            "中藥飲片與顆粒治療",
+            "生活作息與食療指導",
+            "中醫經典研習課程",
+            "線上複診追蹤",
+            "安睡養心方案",
+            "代謝調理計畫",
+            "情志調暢與壓力管理"
         ]
     }
     </script>
@@ -80,23 +80,23 @@
         <div class="nav-container">
             <div class="nav-logo">
                 <i class="fas fa-leaf"></i>
-                <span>Heritage TCM</span>
+                <span>承古堂</span>
             </div>
             <ul class="nav-menu">
-                <li class="nav-item"><a href="#home" class="nav-link">Home</a></li>
-                <li class="nav-item"><a href="#books" class="nav-link">Reading List</a></li>
-                <li class="nav-item"><a href="food-nutrition.html" class="nav-link">TCM Nutrition</a></li>
-                <li class="nav-item"><a href="#about" class="nav-link">About</a></li>
-                <li class="nav-item"><a href="famous-tcm-doctors.html" class="nav-link">Practitioners</a></li>
-                <li class="nav-item"><a href="ni-haixia.html" class="nav-link">Dr. Ni Hai-Xia</a></li>
-                <li class="nav-item"><a href="zhongyao.html" class="nav-link">Herbal Library</a></li>
-                <li class="nav-item"><a href="babu-jingang-gong.html" class="nav-link">Ba Duan Jin</a></li>
-                <li class="nav-item"><a href="ba-duan-jin.html" class="nav-link">Eight Brocades</a></li>
+                <li class="nav-item"><a href="#home" class="nav-link">首頁</a></li>
+                <li class="nav-item"><a href="#books" class="nav-link">經典書單</a></li>
+                <li class="nav-item"><a href="food-nutrition.html" class="nav-link">中醫飲食</a></li>
+                <li class="nav-item"><a href="#about" class="nav-link">關於我們</a></li>
+                <li class="nav-item"><a href="famous-tcm-doctors.html" class="nav-link">名醫薈萃</a></li>
+                <li class="nav-item"><a href="ni-haixia.html" class="nav-link">倪海廈醫師</a></li>
+                <li class="nav-item"><a href="zhongyao.html" class="nav-link">本草庫</a></li>
+                <li class="nav-item"><a href="babu-jingang-gong.html" class="nav-link">八部金剛功</a></li>
+                <li class="nav-item"><a href="ba-duan-jin.html" class="nav-link">八段錦</a></li>
             </ul>
             <div class="nav-actions">
-                <button class="bookmark-btn" id="bookmarkBtn" title="Bookmark this page">
+                <button class="bookmark-btn" id="bookmarkBtn" title="將本頁加入書籤">
                     <i class="fas fa-bookmark"></i>
-                    <span>Bookmark</span>
+                    <span>收藏</span>
                 </button>
             </div>
             <div class="hamburger">
@@ -123,52 +123,52 @@
     <section id="shennong" class="shennong-section">
         <div class="container">
             <div class="section-header">
-                <p class="section-eyebrow">Rooted in two millennia of herbal wisdom</p>
-                <h2 class="section-title">Shennong Materia Medica</h2>
-                <p class="section-subtitle">Explore cornerstone herbs from the <em>Shennong Bencao Jing</em>. We summarise flavour, nature, and indications across all three classical grades so you can absorb the essentials at your own pace.</p>
+                <p class="section-eyebrow">承載兩千年的本草智慧</p>
+                <h2 class="section-title">神農本草精要</h2>
+                <p class="section-subtitle">精選《神農本草經》代表藥味，依味性、歸經、主治三品分類撮要，讓您循序掌握核心要點。</p>
             </div>
 
-            <section class="food-nutrition-highlight" aria-label="Popular dishes and nutrition">
+            <section class="food-nutrition-highlight" aria-label="人氣藥膳與營養重點">
                 <header class="highlight-header">
-                    <span class="highlight-eyebrow">Food as Medicine</span>
-                    <h3 class="highlight-title">Quick Nutrition Snapshots</h3>
-                    <p class="highlight-description">Blend whole grains, legumes, and seasonal produce into everyday meals. You’ll capture the fibre and phytonutrients celebrated by modern nutrition while honouring the TCM idea that healing begins in the kitchen.</p>
+                    <span class="highlight-eyebrow">藥食同源</span>
+                    <h3 class="highlight-title">飲食重點速覽</h3>
+                    <p class="highlight-description">以全穀、雜豆與當季蔬果入菜，兼顧現代營養所重視的纖維與植化素，同時實踐「醫食相輔」的中醫理念。</p>
                 </header>
                 <div class="highlight-grid">
                     <article class="highlight-card">
-                        <h4 class="highlight-food">Oat Congee</h4>
-                        <p class="highlight-nutrients">Dietary fibre 3.5 g · Plant protein 5.9 g · Rich in beta-glucan</p>
-                        <p class="highlight-note">Moistens dryness, gently supports the stomach, and steadies post-meal blood sugar. Pair with jujube or goji for extra qi and blood nourishment and enjoy warm in the morning to keep digestion moving.</p>
+                        <h4 class="highlight-food">燕麥粥</h4>
+                        <p class="highlight-nutrients">膳食纖維 3.5 克 · 植物蛋白 5.9 克 · 富含β-葡聚醣</p>
+                        <p class="highlight-note">潤燥養胃、餐後平穩血糖。可搭配紅棗、枸杞補氣養血，晨起溫食有助脾胃運化。</p>
                     </article>
                     <article class="highlight-card">
-                        <h4 class="highlight-food">Chinese Yam &amp; Job’s Tears Porridge</h4>
-                        <p class="highlight-nutrients">Complex carbs · Protein 4.1 g · Potassium &amp; B vitamins</p>
-                        <p class="highlight-note">Chinese yam fortifies the spleen and boosts qi, while Job’s tears transform dampness. Together they replenish energy and drain heaviness—ideal for those feeling sluggish or puffy.</p>
+                        <h4 class="highlight-food">山藥薏仁粥</h4>
+                        <p class="highlight-nutrients">複合碳水 · 蛋白質 4.1 克 · 含鉀與維生素 B 群</p>
+                        <p class="highlight-note">山藥健脾益氣，薏仁健脾滲濕，雙管齊下補足元氣並化解沉重水濕，適合覺得疲倦、身體浮腫者。</p>
                     </article>
                     <article class="highlight-card">
-                        <h4 class="highlight-food">Snow Fungus &amp; Lotus Seed Dessert</h4>
-                        <p class="highlight-nutrients">Polysaccharides · Fibre · Plant calcium &amp; potassium</p>
-                        <p class="highlight-note">Snow fungus nourishes lung yin and fluids, lotus seeds calm the spirit, and a sprinkle of goji berries supports liver and kidney balance. A comforting evening dessert that doesn’t create excess heat.</p>
+                        <h4 class="highlight-food">銀耳蓮子甜品</h4>
+                        <p class="highlight-nutrients">多醣體 · 纖維 · 植物鈣與鉀</p>
+                        <p class="highlight-note">銀耳滋潤肺陰、生津止渴，蓮子寧心安神，佐以枸杞調和肝腎，溫潤不燥，適合作為入夜甜湯。</p>
                     </article>
                     <article class="highlight-card">
-                        <h4 class="highlight-food">Black Sesame Elixir</h4>
-                        <p class="highlight-nutrients">Unsaturated fats · Calcium 780 mg · Vitamin E</p>
-                        <p class="highlight-note">Black sesame seeds replenish liver and kidney yin, promote glossy hair, and ease dryness. Blend with walnut powder to sharpen memory and nourish bones—excellent for students and elders alike.</p>
+                        <h4 class="highlight-food">黑芝麻糊</h4>
+                        <p class="highlight-nutrients">不飽和脂肪 · 鈣質 780 毫克 · 維生素 E</p>
+                        <p class="highlight-note">黑芝麻補肝腎、潤燥養髮，佐核桃粉益智健骨，學生與長者皆宜，溫潤順口。</p>
                     </article>
                 </div>
             </section>
 
             <div class="herb-toolbar">
                 <div class="herb-search">
-                    <label for="homepageHerbSearch"><i class="fas fa-search"></i><span>Find an herb fast</span></label>
-                    <input type="search" id="homepageHerbSearch" placeholder="Search by herb name or therapeutic action...">
+                    <label for="homepageHerbSearch"><i class="fas fa-search"></i><span>快速查找本草</span></label>
+                    <input type="search" id="homepageHerbSearch" placeholder="輸入藥名或功效關鍵字…">
                 </div>
-                <div class="herb-counter" id="homepageHerbCounter">0 herbs listed</div>
+                <div class="herb-counter" id="homepageHerbCounter">列出 0 味藥</div>
             </div>
 
             <div id="homepageHerbList" class="herbs-grid" aria-live="polite"></div>
 
-            <nav class="herb-pagination" id="homepageHerbPagination" aria-label="Shennong Materia Medica pagination"></nav>
+            <nav class="herb-pagination" id="homepageHerbPagination" aria-label="神農本草分頁導覽"></nav>
         </div>
     </section>
 
@@ -176,31 +176,31 @@
     <section id="about" class="about-section">
         <div class="container">
             <div class="section-header">
-                <h2 class="section-title">About Our Collective</h2>
-                <p class="section-subtitle">Preserving the heart of Traditional Chinese Medicine while making it accessible to a global English-speaking community.</p>
+                <h2 class="section-title">關於承古堂</h2>
+                <p class="section-subtitle">守護中醫本心，以繁體中文深入淺出，陪伴每一位渴望理解經典的人。</p>
             </div>
 
             <div class="about-content">
                 <div class="about-text">
-                    <p>We are a network of herbalists, acupuncturists, and educators who study the classics and apply them to modern lifestyles. From personalised herbal formulas to self-care routines, we help you understand why each recommendation fits your constitution.</p>
+                    <p>我們由中醫師、藥師與講師共同組成，潛心研讀經典並融會於當代生活。無論是量身配方還是日常調攝，都重視辨證根據，讓您明白每一步調理如何貼合體質。</p>
                 </div>
 
                 <div class="about-stats">
                     <div class="stat-item">
                         <div class="stat-number">20+</div>
-                        <div class="stat-label">years of collective clinical experience</div>
+                        <div class="stat-label">臨床經驗累積年數</div>
                     </div>
                     <div class="stat-item">
                         <div class="stat-number">1000+</div>
-                        <div class="stat-label">herbal ingredients sourced responsibly</div>
+                        <div class="stat-label">妥善溯源的藥材</div>
                     </div>
                     <div class="stat-item">
                         <div class="stat-number">50000+</div>
-                        <div class="stat-label">consultations supported worldwide</div>
+                        <div class="stat-label">守護個案遍及全球</div>
                     </div>
                     <div class="stat-item">
                         <div class="stat-number">98%</div>
-                        <div class="stat-label">client satisfaction across follow-ups</div>
+                        <div class="stat-label">複診滿意度</div>
                     </div>
                 </div>
             </div>
@@ -211,56 +211,56 @@
     <section id="books" class="books-section">
         <div class="container">
             <div class="section-header">
-                <h2 class="section-title">Essential Reading</h2>
-                <p class="section-subtitle">Curated classical texts and modern guides that reveal how Traditional Chinese Medicine thinks, diagnoses, and heals.</p>
+                <h2 class="section-title">必讀經典</h2>
+                <p class="section-subtitle">精挑細選的古籍與當代詮釋，展現中醫思維、辨證與療法的全貌。</p>
             </div>
 
             <div class="books-grid">
                 <article class="book-card">
                     <div class="book-info">
                         <h3 class="book-title"><em>Huangdi Neijing</em></h3>
-                        <p class="book-meta">Meridians · Viscera · Foundational theory</p>
-                        <p class="book-description">The definitive source on yin-yang dynamics, five phases, organ systems, and pattern differentiation—essential for grasping TCM’s holistic worldview.</p>
+                        <p class="book-meta">經絡 · 臟腑 · 基礎理論</p>
+                        <p class="book-description">奠定陰陽、五行與臟腑辨證基礎，是理解中醫整體觀不可或缺的經典。</p>
                     </div>
                 </article>
 
                 <article class="book-card">
                     <div class="book-info">
                         <h3 class="book-title"><em>Shang Han Lun</em></h3>
-                        <p class="book-meta">Six conformations · Classical formulas</p>
-                        <p class="book-description">Zhang Zhongjing’s clinical masterpiece detailing how pathogenic cold moves through the body and how targeted formulas restore balance.</p>
+                        <p class="book-meta">六經辨證 · 經方運用</p>
+                        <p class="book-description">張仲景臨床巨著，闡述傷寒傳變脈絡與經方施治原則，精準指導臨床用藥。</p>
                     </div>
                 </article>
 
                 <article class="book-card">
                     <div class="book-info">
                         <h3 class="book-title"><em>Jinkui Yaolue</em></h3>
-                        <p class="book-meta">Internal medicine · Formula differentiation</p>
-                        <p class="book-description">A companion to the <em>Shang Han Lun</em> covering chronic and organ-related disorders. Each formula is matched to precise signs, guiding nuanced treatment.</p>
+                        <p class="book-meta">內科雜病 · 方證對應</p>
+                        <p class="book-description">與《傷寒論》相輔，詳述臟腑慢性病證，逐條對應症狀與方藥，利於細膩辨證。</p>
                     </div>
                 </article>
 
                 <article class="book-card">
                     <div class="book-info">
                         <h3 class="book-title"><em>Shennong Bencao Jing</em></h3>
-                        <p class="book-meta">Materia medica origins · Herbal energetics</p>
-                        <p class="book-description">The earliest pharmacopoeia, classifying 365 herbs into superior, moderate, and regular grades and establishing the language of taste, temperature, and channel entry.</p>
+                        <p class="book-meta">本草源頭 · 藥性精義</p>
+                        <p class="book-description">最早的藥典，依上中下品分列三百六十五味，奠定味性歸經等本草語彙。</p>
                     </div>
                 </article>
 
                 <article class="book-card book-card--no-cover">
                     <div class="book-info">
                         <h3 class="book-title"><em>Nanjing</em></h3>
-                        <p class="book-meta">Meridians &amp; pulse · Q&amp;A insights</p>
-                        <p class="book-description">Forty-nine classic questions that clarify difficult passages from the <em>Inner Canon</em>, offering practitioners guidance on pulse interpretation and channel theory.</p>
+                        <p class="book-meta">經脈診脈 · 問答闡義</p>
+                        <p class="book-description">以四十九難釐清《內經》疑義，指引醫者掌握經脈脈象與診法重點。</p>
                     </div>
                 </article>
 
                 <article class="book-card book-card--no-cover">
                     <div class="book-info">
                         <h3 class="book-title"><em>Wen Bing Tiao Bian</em></h3>
-                        <p class="book-meta">Defensive-qi-nutrient-blood · Warm pathogen theory</p>
-                        <p class="book-description">Wu Jutong maps how heat pathogens progress from the exterior to deeper levels, offering modern relevance for febrile and viral conditions.</p>
+                        <p class="book-meta">衛氣營血 · 溫病理論</p>
+                        <p class="book-description">吳鞠通梳理溫熱病從表入裡的演變，為現代熱性病與感染提供辨證思路。</p>
                     </div>
                 </article>
             </div>
@@ -271,88 +271,88 @@
     <section id="faq" class="faq-section">
         <div class="container">
             <div class="section-header">
-                <h2 class="section-title">Frequently Asked Questions</h2>
-                <p class="section-subtitle">Honest answers to the questions we hear most about living and healing with Traditional Chinese Medicine.</p>
+                <h2 class="section-title">常見問題</h2>
+                <p class="section-subtitle">針對大家對中醫調理最在意的疑問，提供真誠詳盡的解答。</p>
             </div>
 
             <div class="faq-content">
                 <div class="faq-item">
                     <div class="faq-question">
-                        <h3>How long does it take to feel results from herbal therapy?</h3>
+                        <h3>服用中藥多久會見效？</h3>
                         <i class="fas fa-chevron-down"></i>
                     </div>
                     <div class="faq-answer">
-                        <p>Everyone’s constitution responds differently. Acute concerns may ease within one to two weeks, while deeper imbalances often require one to three months of consistent care. We reassess at each follow-up and adjust formulas to meet your progress.</p>
+                        <p>每個人體質不同，急性症狀約一至兩週可見轉變，體質深層失衡則需持續一至三個月漸進調理。我們於每次複診檢視舌脈與反應，隨症加減，以貼合您的步調。</p>
                     </div>
                 </div>
 
                 <div class="faq-item">
                     <div class="faq-question">
-                        <h3>Are there side effects with Chinese herbal medicine?</h3>
+                        <h3>中藥會有副作用嗎？</h3>
                         <i class="fas fa-chevron-down"></i>
                     </div>
                     <div class="faq-answer">
-                        <p>When prescribed appropriately, herbs are gentle and balanced. We screen for allergies, drug interactions, and quality sourcing. Follow the recommended dosage, observe how you feel, and contact us immediately if anything feels off so we can fine-tune.</p>
+                        <p>辨證用藥講究配伍平衡，合宜服用多半溫和。我們會先了解過敏史、現用藥物與藥材來源，提醒您遵循劑量並隨時回報感受，一旦有不適立即調整處方。</p>
                     </div>
                 </div>
 
                 <div class="faq-item">
                     <div class="faq-question">
-                        <h3>How do you decide which herbs are right for me?</h3>
+                        <h3>如何判斷適合我的方藥？</h3>
                         <i class="fas fa-chevron-down"></i>
                     </div>
                     <div class="faq-answer">
-                        <p>We begin with a thorough TCM intake—observing tongue, pulse, lifestyle, and emotions. Patterns of disharmony guide the formula. As your body shifts, we adjust the ratio of herbs to keep the treatment specific and effective.</p>
+                        <p>會先進行完整的中醫問診，觀察舌象、脈象與起居情緒，依失調的證型選方用藥。隨著身體轉變，會適時調整藥味比例，確保治療精準有效。</p>
                     </div>
                 </div>
 
                 <div class="faq-item">
                     <div class="faq-question">
-                        <h3>Do you offer wholesale sourcing for clinics?</h3>
+                        <h3>是否提供診所批發藥材？</h3>
                         <i class="fas fa-chevron-down"></i>
                     </div>
                     <div class="faq-answer">
-                        <p>Yes. Licensed practitioners and pharmacies can partner with us for sustainably grown raw herbs and granules. Minimum orders apply so we can maintain freshness. Reach out with your credentials and we will arrange a sourcing plan.</p>
+                        <p>可以。合格醫療院所與藥局可合作採購友善栽植的飲片與顆粒。為維持品質，新客需達最低訂購量，請備妥證照資料與需求，我們會協助規畫供應方案。</p>
                     </div>
                 </div>
 
                 <div class="faq-item">
                     <div class="faq-question">
-                        <h3>What’s the difference between decoctions and convenient tea sachets?</h3>
+                        <h3>煎煮湯藥與茶包有何差別？</h3>
                         <i class="fas fa-chevron-down"></i>
                     </div>
                     <div class="faq-answer">
-                        <p>Traditional decoctions are simmered for 30–45 minutes and offer the richest potency. Sachets provide pre-measured herbs you can steep on busy days. We help you combine both approaches so convenience never sacrifices therapeutic depth.</p>
+                        <p>傳統湯劑需熬煮三、四十分鐘，藥力最為充足；茶包則方便快泡，適合忙碌時段。我們會依情況搭配，兼顧療效與便利性。</p>
                     </div>
                 </div>
 
                 <div class="faq-item">
                     <div class="faq-question">
-                        <h3>How do you ensure rare herbs are authentic?</h3>
+                        <h3>如何確保珍稀藥材真偽？</h3>
                         <i class="fas fa-chevron-down"></i>
                     </div>
                     <div class="faq-answer">
-                        <p>We work with growers who use third-party lab testing and traditional organoleptic checks. Certificates of analysis accompany premium botanicals, and our team inspects appearance, aroma, and texture before anything reaches your hands.</p>
+                        <p>我們與通過第三方檢測的產地合作，並以傳統望聞問切辨藥法檢視。頂級藥材附上成分檢測報告，團隊也會逐批查驗色澤、氣味與質地，確保純正。</p>
                     </div>
                 </div>
 
                 <div class="faq-item">
                     <div class="faq-question">
-                        <h3>Can TCM help with weight management safely?</h3>
+                        <h3>中醫能安全協助體重管理嗎？</h3>
                         <i class="fas fa-chevron-down"></i>
                     </div>
                     <div class="faq-answer">
-                        <p>Rather than chasing quick fixes, we regulate digestion, transform dampness, and calm stress-driven cravings. Personalised herbs pair with meal rhythm and movement strategies so weight shifts feel steady and supportive.</p>
+                        <p>中醫重視調和脾胃、化濕與穩定情志，而非追求速效。透過個人化方藥搭配飲食節律與溫和運動，讓體重變化穩健又不傷正氣。</p>
                     </div>
                 </div>
 
                 <div class="faq-item">
                     <div class="faq-question">
-                        <h3>How does TCM approach beauty and skin health?</h3>
+                        <h3>中醫如何調理膚質與美顏？</h3>
                         <i class="fas fa-chevron-down"></i>
                     </div>
                     <div class="faq-answer">
-                        <p>Radiant skin starts within. We use herbs and food therapy to nourish blood, move qi, and clear heat. Topical masks, botanical steams, and facial gua sha support circulation from the outside for a naturally luminous glow.</p>
+                        <p>好氣色源自內在。透過藥食同調補血行氣、清熱解毒，再配合外用敷貼、草本蒸臉與刮痧，內外兼顧養出自然光采。</p>
                     </div>
                 </div>
             </div>
@@ -364,41 +364,41 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-section">
-                    <h3>Heritage TCM</h3>
-                    <p>Carrying the classics forward with practitioners who blend scholarly insight and compassionate care.</p>
+                    <h3>承古堂</h3>
+                    <p>由臨床與教學兼備的醫者，以仁心與學養承續經典。</p>
                     <div class="social-links">
-                        <a href="#" title="WeChat: zhangyouxun2013"><i class="fab fa-weixin"></i></a>
-                        <a href="#" title="Email: hello@heritagetcm.com"><i class="fas fa-envelope"></i></a>
-                        <a href="#" title="Phone: +1-407-555-1688"><i class="fas fa-phone"></i></a>
+                        <a href="#" title="微信：zhangyouxun2013"><i class="fab fa-weixin"></i></a>
+                        <a href="#" title="電子信箱：hello@heritagetcm.com"><i class="fas fa-envelope"></i></a>
+                        <a href="#" title="電話：+1-407-555-1688"><i class="fas fa-phone"></i></a>
                     </div>
                 </div>
 
                 <div class="footer-section">
-                    <h4>Quick Links</h4>
+                    <h4>快速連結</h4>
                     <ul>
-                        <li><a href="#home">Home</a></li>
-                        <li><a href="#shennong">Herbal highlights</a></li>
-                        <li><a href="#about">About</a></li>
-                        <li><a href="#books">Reading list</a></li>
-                        <li><a href="#faq">FAQ</a></li>
-                        <li><a href="zhongyao.html">Materia medica atlas</a></li>
-                        <li><a href="ba-duan-jin.html">Eight Brocades</a></li>
+                        <li><a href="#home">首頁</a></li>
+                        <li><a href="#shennong">本草精選</a></li>
+                        <li><a href="#about">關於我們</a></li>
+                        <li><a href="#books">經典書單</a></li>
+                        <li><a href="#faq">常見問題</a></li>
+                        <li><a href="zhongyao.html">本草圖鑑</a></li>
+                        <li><a href="ba-duan-jin.html">八段錦</a></li>
                     </ul>
                 </div>
 
                 <div class="footer-section">
-                    <h4>Contact</h4>
+                    <h4>聯絡方式</h4>
                     <ul>
-                        <li><i class="fab fa-weixin"></i> WeChat: zhangyouxun2013</li>
-                        <li><i class="fas fa-envelope"></i> Email: hello@heritagetcm.com</li>
-                        <li><i class="fas fa-phone"></i> Phone: +1-407-555-1688</li>
-                        <li><i class="fas fa-clock"></i> Office hours: 8:00–22:00 (UTC-5)</li>
+                        <li><i class="fab fa-weixin"></i> 微信：zhangyouxun2013</li>
+                        <li><i class="fas fa-envelope"></i> 電子信箱：hello@heritagetcm.com</li>
+                        <li><i class="fas fa-phone"></i> 聯絡電話：+1-407-555-1688</li>
+                        <li><i class="fas fa-clock"></i> 門診時間：08:00–22:00（UTC-5）</li>
                     </ul>
                 </div>
             </div>
 
             <div class="footer-bottom">
-                <p>&copy; 2024 Heritage TCM. All rights reserved. | Classical formulas · Preventive care · Heartfelt guidance</p>
+                <p>&copy; 2024 承古堂。保留所有權利｜經方臨床・預防調養・真誠陪伴</p>
             </div>
         </div>
     </footer>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-    "name": "Heritage TCM",
-    "short_name": "Heritage TCM",
-    "description": "Classical Chinese Medicine insights, herbal spotlights, movement guides, and nutrition tips for an English-speaking audience.",
+    "name": "承古堂中醫",
+    "short_name": "承古堂",
+    "description": "提供中醫經典解讀、本草精選、養生功法與飲食指南的繁體中文資源。",
     "start_url": "/index.html",
     "display": "standalone",
     "background_color": "#1a8f5f",

--- a/ni-haixia.html
+++ b/ni-haixia.html
@@ -1,23 +1,23 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dr. Ni Hai-Xia | Heritage TCM</title>
-    <meta name="description" content="Explore the life, teaching style, and resources of Dr. Ni Hai-Xia, founder of Han Tang Chinese Medicine.">
+    <title>倪海廈醫師｜承古堂</title>
+    <meta name="description" content="認識漢唐中醫創辦人倪海廈醫師的生平、授課風格與研習資源。">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 </head>
 <body class="nhx-page">
     <nav class="nhx-nav">
         <div class="nav-inner">
-            <a class="brand" href="index.html"><i class="fas fa-compass"></i>Heritage TCM</a>
+            <a class="brand" href="index.html"><i class="fas fa-compass"></i>承古堂</a>
             <div class="nav-links">
-                <a href="#biography">Biography</a>
-                <a href="#teaching">Teaching Philosophy</a>
-                <a href="#courses">Courses &amp; Books</a>
-                <a href="#media">Media Library</a>
-                <a href="#resources">Study Resources</a>
+                <a href="#biography">生平軌跡</a>
+                <a href="#teaching">教學理念</a>
+                <a href="#courses">課程出版</a>
+                <a href="#media">影音精選</a>
+                <a href="#resources">研習資源</a>
             </div>
         </div>
     </nav>
@@ -26,12 +26,12 @@
         <div class="hero-overlay"></div>
         <div class="hero-content">
             <div class="hero-text">
-                <h1>Dr. Ni Hai-Xia</h1>
-                <p>Founder of Han Tang Chinese Medicine. An energetic bridge between the classical texts and modern seekers, Dr. Ni showed students how astronomy, meridians, and herbal formulas weave together to support real people.</p>
+                <h1>倪海廈醫師</h1>
+                <p>漢唐中醫創辦人，以熱情活力串連經典與現代，將天文、經絡與經方融合，教導學員如何貼近實際病家。</p>
                 <div class="hero-meta">
                     <span class="tag">1954–2012</span>
-                    <span class="tag">Classical Formulas</span>
-                    <span class="tag">Global Educator</span>
+                    <span class="tag">經方醫案</span>
+                    <span class="tag">跨國講師</span>
                 </div>
             </div>
             <figure class="hero-portrait">
@@ -43,121 +43,121 @@
     <main class="nhx-main">
         <section id="biography" class="nhx-section">
             <div class="section-header">
-                <p class="section-eyebrow">Life &amp; Milestones</p>
-                <h2 class="section-title">From Taiwan to the world</h2>
-                <p class="section-subtitle">Dr. Ni practised in Taiwan before moving to Florida, where he founded Han Tang Chinese Medicine and began teaching internationally.</p>
+                <p class="section-eyebrow">生平足跡</p>
+                <h2 class="section-title">從臺灣走向世界</h2>
+                <p class="section-subtitle">倪醫師先在臺灣臨床行醫，後移居美國佛州創辦漢唐中醫，開啟國際授課之路。</p>
             </div>
             <div class="timeline">
                 <article class="timeline-card">
-                    <h3>Early Training</h3>
-                    <p>Studied classical texts under mentors steeped in the Han dynasty lineage, with a special devotion to the <em>Shang Han Lun</em> and <em>Jinkui Yaolue</em>.</p>
+                    <h3>早年學養</h3>
+                    <p>師承漢代經方傳脈，尤重《傷寒論》《金匱要略》，奠定扎實的經典功底。</p>
                 </article>
                 <article class="timeline-card">
-                    <h3>Han Tang Clinic</h3>
-                    <p>Established the Han Tang clinic in Orlando, Florida, treating patients with customised classical prescriptions and acupuncture.</p>
+                    <h3>漢唐醫館</h3>
+                    <p>於美國奧蘭多創立漢唐中醫，以經方與針灸為患者量身調理。</p>
                 </article>
                 <article class="timeline-card">
-                    <h3>Global Teaching</h3>
-                    <p>Launched seminars across North America, Europe, and Asia, pairing vivid case studies with astronomical observations.</p>
+                    <h3>全球授課</h3>
+                    <p>足跡遍及美洲、歐洲與亞洲，以實案結合天文推演，啟發無數學員。</p>
                 </article>
             </div>
         </section>
 
         <section id="teaching" class="nhx-section">
             <div class="section-header">
-                <p class="section-eyebrow">Signature Approach</p>
-                <h2 class="section-title">How Dr. Ni taught</h2>
-                <p class="section-subtitle">A balance of rigorous classics and everyday language made his lectures unforgettable.</p>
+                <p class="section-eyebrow">教學風格</p>
+                <h2 class="section-title">倪醫師如何授課</h2>
+                <p class="section-subtitle">嚴謹經典搭配生活語彙，讓課堂深入人心。</p>
             </div>
             <div class="teaching-grid">
                 <article>
-                    <h3>Story-driven lectures</h3>
-                    <p>Complex theories were broken into vivid stories—patients became “friends” whose patterns we followed from symptom to symptom.</p>
+                    <h3>以故事串聯</h3>
+                    <p>將繁複理論化為真實案例，患者如朋友般陪伴學習，循症狀追蹤證候。</p>
                 </article>
                 <article>
-                    <h3>Astronomy &amp; Calendrics</h3>
-                    <p>He tracked heavenly stems, earthly branches, and seasonal qi to explain why the same formula behaves differently throughout the year.</p>
+                    <h3>天文曆法觀</h3>
+                    <p>以天干地支與節氣之氣解說方藥效應，說明同一方在不同時令的差異。</p>
                 </article>
                 <article>
-                    <h3>Channel craftsmanship</h3>
-                    <p>Needling and herbal strategies were taught together, always referencing the channels and how herbs travel along them.</p>
+                    <h3>經絡工藝</h3>
+                    <p>針藥並論，隨時對照經絡走向與藥物所行之路，培養整體觀。</p>
                 </article>
             </div>
         </section>
 
         <section id="courses" class="nhx-section">
             <div class="section-header">
-                <p class="section-eyebrow">Learning Pathways</p>
-                <h2 class="section-title">Courses &amp; publications</h2>
-                <p class="section-subtitle">Key resources for students who want to continue exploring Dr. Ni’s legacy.</p>
+                <p class="section-eyebrow">進修指南</p>
+                <h2 class="section-title">課程與出版</h2>
+                <p class="section-subtitle">想持續研習倪醫師傳承，可由以下資源著手。</p>
             </div>
             <div class="resource-grid">
                 <article>
-                    <h3>Classical Formulas Intensive</h3>
-                    <p>A multi-week program dissecting formulas line by line, emphasising how to adjust dosage and ingredients for modern constitutions.</p>
+                    <h3>經方密集班</h3>
+                    <p>多週課程逐條講解方證，著重如何依現代體質調整劑量與配伍。</p>
                 </article>
                 <article>
-                    <h3>Between Heaven and Earth</h3>
-                    <p>A richly illustrated book that introduces the Han Tang approach to channel theory, seasonal health, and lifestyle rituals.</p>
+                    <h3>天地之間</h3>
+                    <p>圖文並陳，介紹漢唐經絡觀、節氣養生與生活儀式。</p>
                 </article>
                 <article>
-                    <h3>Clinic Apprenticeship</h3>
-                    <p>On-site observation at Han Tang Chinese Medicine, combining patient interviews, pulse analysis, and herbal compounding.</p>
+                    <h3>診間實習</h3>
+                    <p>於漢唐醫館隨診，結合問診、切脈與抓方煎製的實務演練。</p>
                 </article>
             </div>
         </section>
 
         <section id="media" class="nhx-section">
             <div class="section-header">
-                <p class="section-eyebrow">Watch &amp; Listen</p>
-                <h2 class="section-title">Popular lectures</h2>
-                <p class="section-subtitle">Curated English-friendly recordings from Dr. Ni’s YouTube archive. Subtitles available on each video.</p>
+                <p class="section-eyebrow">視聽學習</p>
+                <h2 class="section-title">人氣講座</h2>
+                <p class="section-subtitle">精選倪醫師影音課程，附中文字幕與重點整理。</p>
             </div>
             <div class="media-grid">
                 <article class="media-card">
-                    <iframe src="https://www.youtube.com/embed/1dTH0PjzvCk" title="Six Conformations Explained" loading="lazy" allowfullscreen></iframe>
-                    <h3>Six Conformations Explained</h3>
-                    <span>1.5M views · Understanding the tidal movement from Taiyang to Jueyin.</span>
+                    <iframe src="https://www.youtube.com/embed/1dTH0PjzvCk" title="六經傳變速覽" loading="lazy" allowfullscreen></iframe>
+                    <h3>六經傳變速覽</h3>
+                    <span>150 萬次觀看｜解析太陽至厥陰的潮汐律動。</span>
                 </article>
                 <article class="media-card">
-                    <iframe src="https://www.youtube.com/embed/8SdnzM2KQh4" title="Clinical Pearls from Jinkui Yaolue" loading="lazy" allowfullscreen></iframe>
-                    <h3>Clinical Pearls from the <em>Jinkui</em></h3>
-                    <span>1.2M views · Case-based lessons on chronic internal medicine.</span>
+                    <iframe src="https://www.youtube.com/embed/8SdnzM2KQh4" title="金匱臨床要訣" loading="lazy" allowfullscreen></iframe>
+                    <h3><em>金匱</em>臨床要訣</h3>
+                    <span>120 萬次觀看｜慢性內科證治案例剖析。</span>
                 </article>
                 <article class="media-card">
-                    <iframe src="https://www.youtube.com/embed/3Jb5rLxN6BY" title="Channel Theory in Practice" loading="lazy" allowfullscreen></iframe>
-                    <h3>Channel Theory in Practice</h3>
-                    <span>980K views · Combining needling with herbal adjustments.</span>
+                    <iframe src="https://www.youtube.com/embed/3Jb5rLxN6BY" title="經絡實務運用" loading="lazy" allowfullscreen></iframe>
+                    <h3>經絡實務運用</h3>
+                    <span>98 萬次觀看｜針藥合參的臨床示範。</span>
                 </article>
             </div>
         </section>
 
         <section id="resources" class="nhx-section">
             <div class="section-header">
-                <p class="section-eyebrow">Keep Studying</p>
-                <h2 class="section-title">Guides &amp; communities</h2>
-                <p class="section-subtitle">Join fellow practitioners who are committed to carrying forward Dr. Ni’s teachings.</p>
+                <p class="section-eyebrow">持續研修</p>
+                <h2 class="section-title">指南與社群</h2>
+                <p class="section-subtitle">與同道相伴，延續倪醫師的教學精神。</p>
             </div>
             <div class="resource-grid">
                 <article>
-                    <h3>Downloadable study packets</h3>
-                    <p>PDF companions for the <em>Shang Han Lun</em> and <em>Jinkui</em> lectures, including formula charts, stem-branch calendars, and case transcription notes.</p>
+                    <h3>下載式講義</h3>
+                    <p>搭配《傷寒》《金匱》課程的 PDF，含方證表、干支曆與案例紀錄。</p>
                 </article>
                 <article>
-                    <h3>Global discussion groups</h3>
-                    <p>Online meetups that review cases, host guest lecturers, and provide accountability for ongoing study.</p>
+                    <h3>國際討論社</h3>
+                    <p>線上聚會討論案例、邀請講者分享，彼此督促持續進修。</p>
                 </article>
                 <article>
-                    <h3>Han Tang Clinic directory</h3>
-                    <p>Connect with practitioners trained in the Han Tang method for referrals or mentorship.</p>
+                    <h3>漢唐醫師名錄</h3>
+                    <p>連結受訓醫師，便於轉介或尋求指導。</p>
                 </article>
             </div>
         </section>
     </main>
 
     <footer class="nhx-footer">
-        <p>&copy; 2024 Heritage TCM. Inspired by the teachings of Dr. Ni Hai-Xia.</p>
-        <p><a href="index.html">Return to the homepage</a> · <a href="famous-tcm-doctors.html">More influential practitioners</a></p>
+        <p>&copy; 2024 承古堂。靈感源自倪海廈醫師的教誨。</p>
+        <p><a href="index.html">回到首頁</a> · <a href="famous-tcm-doctors.html">更多影響力名家</a></p>
     </footer>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -89,7 +89,7 @@ function initForms() {
     if (consultationForm) {
         consultationForm.addEventListener('submit', event => {
             event.preventDefault();
-            handleFormSubmission(consultationForm, 'Consultation request');
+            handleFormSubmission(consultationForm, '諮詢需求');
         });
     }
 
@@ -97,16 +97,16 @@ function initForms() {
     if (contactForm) {
         contactForm.addEventListener('submit', event => {
             event.preventDefault();
-            handleFormSubmission(contactForm, 'Message');
+            handleFormSubmission(contactForm, '訊息');
         });
     }
 }
 
 function handleFormSubmission(form, label) {
     const data = Object.fromEntries(new FormData(form).entries());
-    showNotification(`${label} received! We will be in touch soon.`, 'success');
+    showNotification(`已收到${label}，我們會盡快與您聯繫。`, 'success');
     form.reset();
-    console.log('Form submission preview:', data);
+    console.log('表單內容預覽：', data);
 }
 
 function showNotification(message, type = 'info') {

--- a/zhongyao.html
+++ b/zhongyao.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hant">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Shennong Materia Medica | Heritage TCM</title>
-    <meta name="description" content="Browse classical herbs from the Shennong Bencao Jing with quick filters and original text snippets.">
+    <title>神農本草圖鑑｜承古堂</title>
+    <meta name="description" content="快速篩選《神農本草經》經典藥味，閱讀原文提要與三品分類，掌握藥性精髓。">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 </head>
@@ -13,12 +13,12 @@
         <div class="nav-container">
             <div class="nav-logo">
                 <i class="fas fa-leaf"></i>
-                <span>Heritage TCM</span>
+                <span>承古堂</span>
             </div>
             <ul class="nav-menu">
-                <li class="nav-item"><a href="index.html#shennong" class="nav-link">Herbal highlights</a></li>
-                <li class="nav-item"><a href="zhongyao.html" class="nav-link active">Materia Medica</a></li>
-                <li class="nav-item"><a href="ba-duan-jin.html" class="nav-link">Eight Brocades</a></li>
+                <li class="nav-item"><a href="index.html#shennong" class="nav-link">本草精選</a></li>
+                <li class="nav-item"><a href="zhongyao.html" class="nav-link active">本草圖鑑</a></li>
+                <li class="nav-item"><a href="ba-duan-jin.html" class="nav-link">八段錦</a></li>
             </ul>
             <div class="hamburger">
                 <span class="bar"></span>
@@ -30,8 +30,8 @@
 
     <header class="page-header hero-herb">
         <div class="container">
-            <h1 class="page-title">Shennong Materia Medica Digest</h1>
-            <p class="page-subtitle">A concise, English-friendly reference drawn from the <em>Shennong Bencao Jing</em>. Filter by grade or search for a specific herb to read its classical description.</p>
+            <h1 class="page-title">神農本草精華導覽</h1>
+            <p class="page-subtitle">萃取《神農本草經》重點，提供繁體中文摘要，可依上中下品或藥名檢索閱讀原文精義。</p>
         </div>
     </header>
 
@@ -40,20 +40,20 @@
             <div class="container">
                 <div class="control-grid">
                     <div class="control-group">
-                        <label for="herbSearch"><i class="fas fa-search"></i> Search by name or action</label>
-                        <input type="search" id="herbSearch" placeholder="Type an herb, action, or snippet of text...">
+                        <label for="herbSearch"><i class="fas fa-search"></i> 藥名／功效搜尋</label>
+                        <input type="search" id="herbSearch" placeholder="輸入藥名、功效或原文片段…">
                     </div>
                     <div class="control-group">
-                        <span class="control-label"><i class="fas fa-layer-group"></i> Filter by grade</span>
+                        <span class="control-label"><i class="fas fa-layer-group"></i> 依等級篩選</span>
                         <div class="grade-tabs">
-                            <button type="button" class="grade-tab active" data-grade="all">All</button>
-                            <button type="button" class="grade-tab" data-grade="Superior">Superior</button>
-                            <button type="button" class="grade-tab" data-grade="Medium">Medium</button>
-                            <button type="button" class="grade-tab" data-grade="Regular">Regular</button>
+                            <button type="button" class="grade-tab active" data-grade="all">全部</button>
+                            <button type="button" class="grade-tab" data-grade="Superior">上品</button>
+                            <button type="button" class="grade-tab" data-grade="Medium">中品</button>
+                            <button type="button" class="grade-tab" data-grade="Regular">下品</button>
                         </div>
                     </div>
                 </div>
-                <p class="control-hint">Herbal notes are quoted or paraphrased from the <em>Shennong Bencao Jing</em>. Grades follow the traditional superior, medium, and regular classes.</p>
+                <p class="control-hint">內容擷取或意譯自《神農本草經》，等級依傳統上、中、下品分類呈現。</p>
             </div>
         </section>
 
@@ -67,8 +67,8 @@
 
     <footer class="page-footer">
         <div class="container">
-            <p>&copy; 2024 Heritage TCM. Classical texts, modern clarity.</p>
-            <p class="footer-note">Study responsibly and seek qualified guidance before using any medicinal herb.</p>
+            <p>&copy; 2024 承古堂。經典有據，詮釋清晰。</p>
+            <p class="footer-note">使用藥材前請諮詢合格專業人士，審慎評估體質與禁忌。</p>
         </div>
     </footer>
 

--- a/zhongyao.js
+++ b/zhongyao.js
@@ -1,6 +1,11 @@
 import shennongHerbs from './data/shennong-herbs.js';
 
 const gradeOrder = ['Superior', 'Medium', 'Regular'];
+const gradeLabels = {
+    Superior: '上品',
+    Medium: '中品',
+    Regular: '下品'
+};
 
 document.addEventListener('DOMContentLoaded', () => {
     const listEl = document.getElementById('herbList');
@@ -55,14 +60,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
         statsEl.innerHTML = `
             <div class="stat-card">
-                <span class="stat-label">Total entries</span>
+                <span class="stat-label">收錄藥味總數</span>
                 <span class="stat-value">${total}</span>
             </div>
             ${gradeOrder.map(grade => `
                 <div class="stat-card">
-                    <span class="stat-label">${grade}</span>
+                    <span class="stat-label">${gradeLabels[grade] || grade}</span>
                     <span class="stat-value">${gradeCounts[grade]}</span>
-                    <span class="stat-sub">Visible now: ${filteredCounts[grade]}</span>
+                    <span class="stat-sub">目前顯示：${filteredCounts[grade]}</span>
                 </div>
             `).join('')}
         `;
@@ -76,7 +81,7 @@ document.addEventListener('DOMContentLoaded', () => {
         entry.innerHTML = `
             <header class="herb-entry__header">
                 <div>
-                    <div class="herb-entry__grade">${herb.grade}</div>
+                    <div class="herb-entry__grade">${gradeLabels[herb.grade] || herb.grade}</div>
                     <h3 class="herb-entry__name">${herb.name}</h3>
                 </div>
                 <span class="herb-entry__id">#${String(herb.id).padStart(2, '0')}</span>
@@ -94,7 +99,7 @@ document.addEventListener('DOMContentLoaded', () => {
         listEl.innerHTML = '';
 
         if (!filtered.length) {
-            listEl.innerHTML = `<p class="empty-state">No herbs match the current filters. Try adjusting the search.</p>`;
+            listEl.innerHTML = `<p class="empty-state">目前沒有符合條件的藥味，請調整搜尋或篩選設定。</p>`;
             return;
         }
 


### PR DESCRIPTION
## Summary
- 將首頁、倪海廈專頁、八段錦與八部金剛功等主要頁面全面翻譯為繁體中文，調整導覽、按鈕與標題文字
- 更新歷代名醫專題與本草資料內容，改用繁體中文描述並保留關鍵名詞及拼音
- 本地化腳本、介面提示與網站說明文件，確保操作訊息、統計資訊與 README 均以繁體中文呈現

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1e23d46b883218bde01c482ab4aad