### PR TITLE
Add AdSense loader script to famous doctor profile pages

### DIFF
--- a/famous-doctors/li-ke.html
+++ b/famous-doctors/li-ke.html
@@ -8,6 +8,8 @@
     <meta name="description" content="整理李可医师的生平背景、临床特色与代表贡献，了解其以扶阳救逆与重症急救闻名的中医学术风格。">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
+     crossorigin="anonymous"></script>
 </head>
 <body class="doctor-page">
     <a class="skip-link" href="#main-content">跳到主內容</a>

--- a/famous-doctors/ni-haixia.html
+++ b/famous-doctors/ni-haixia.html
@@ -8,6 +8,8 @@
     <meta name="description" content="聚焦倪海厦医师的生平、医案传承与教学理念，整理其经方临床、天纪课程与带教方式的要点。">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
+     crossorigin="anonymous"></script>
 </head>
 <body class="doctor-page">
     <a class="skip-link" href="#main-content">跳到主內容</a>

--- a/famous-doctors/zhu-danxi.html
+++ b/famous-doctors/zhu-danxi.html
@@ -8,6 +8,8 @@
     <meta name="description" content="介绍金元四大家之一朱丹溪的学术思想、滋阴派理论与代表著作《格致余论》《丹溪心法》。">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
+     crossorigin="anonymous"></script>
 </head>
 <body class="doctor-page">
     <a class="skip-link" href="#main-content">跳到主內容</a>


### PR DESCRIPTION
### Motivation
- Enable AdSense on individual doctor profile pages so ads can be loaded when those pages are served.
- Keep the site consistent with other pages that already include the AdSense loader script.
- Place the script in the document `<head>` to allow ad libraries to initialize early.

### Description
- Inserted the AdSense loader script tag with the client ID into the `<head>` of `famous-doctors/li-ke.html`, `famous-doctors/ni-haixia.html`, and `famous-doctors/zhu-danxi.html`.
- The added script is `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437` and includes the `crossorigin="anonymous"` attribute.
- Changes are limited to static HTML and do not alter existing CSS or JavaScript logic.
- The updated files were staged and committed with the message `Add AdSense script to doctor pages`.

### Testing
- No automated tests were executed for this change because it is a static HTML modification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960b0eb0ef4832199e50a8520ba8092)