### PR TITLE
Add top navigation menu with submenus on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,50 @@
     </script>
 </head>
 <body class="home-xhalr">
+    <nav class="navbar" aria-label="主要導航">
+        <div class="nav-container">
+            <div class="nav-logo">Cheng Gu Tang</div>
+            <ul class="nav-menu" id="primary-menu">
+                <li class="nav-item"><a class="nav-link" href="index.html">呼吸節律</a></li>
+                <li class="nav-item has-submenu">
+                    <a class="nav-link" href="sleep.html">養生工具</a>
+                    <ul class="submenu" aria-label="養生工具子選單">
+                        <li><a href="sleep.html">睡眠養生</a></li>
+                        <li><a href="foodpairing.html">食物輪盤</a></li>
+                        <li><a href="calorie-calculator.html">卡路里計算器</a></li>
+                    </ul>
+                </li>
+                <li class="nav-item has-submenu">
+                    <a class="nav-link" href="meridian-clock.html">時辰經絡</a>
+                    <ul class="submenu" aria-label="時辰經絡子選單">
+                        <li><a href="meridian-clock.html">流注鐘表</a></li>
+                        <li><a href="organ-clock.html">臟腑時鐘</a></li>
+                    </ul>
+                </li>
+                <li class="nav-item has-submenu">
+                    <a class="nav-link" href="ba-duan-jin.html">功法練習</a>
+                    <ul class="submenu" aria-label="功法練習子選單">
+                        <li><a href="ba-duan-jin.html">八段錦</a></li>
+                        <li><a href="babu-jingang-gong.html">八部金剛功</a></li>
+                    </ul>
+                </li>
+                <li class="nav-item has-submenu">
+                    <a class="nav-link" href="ni-haixia.html">人物專題</a>
+                    <ul class="submenu" aria-label="人物專題子選單">
+                        <li><a href="ni-haixia.html">倪海廈專頁</a></li>
+                        <li><a href="chanting-classics.html">誦讀經典</a></li>
+                        <li><a href="brain.html">腦部養護</a></li>
+                    </ul>
+                </li>
+                <li class="nav-item"><a class="nav-link" href="game.html">互動小遊戲</a></li>
+            </ul>
+            <button class="hamburger" aria-label="切換選單" aria-expanded="false" aria-controls="primary-menu">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+        </div>
+    </nav>
     <div class="app-container">
         <main class="breath-hero">
             <div class="hero-header">

--- a/styles.css
+++ b/styles.css
@@ -687,6 +687,50 @@ body.home-xhalr .pulse-checkbox {
     gap: 2rem;
 }
 
+.nav-item {
+    position: relative;
+}
+
+.nav-item.has-submenu > .nav-link::after {
+    content: '▾';
+    margin-left: 0.35rem;
+    font-size: 0.75rem;
+}
+
+.submenu {
+    display: none;
+    position: absolute;
+    top: calc(100% + 0.6rem);
+    left: 0;
+    min-width: 200px;
+    padding: 0.5rem 0;
+    list-style: none;
+    background: rgba(255, 255, 255, 0.98);
+    border: 1px solid rgba(15, 64, 57, 0.12);
+    border-radius: 14px;
+    box-shadow: 0 18px 40px rgba(15, 64, 57, 0.18);
+    z-index: 1010;
+}
+
+.submenu a {
+    display: block;
+    padding: 0.55rem 1.1rem;
+    color: #111;
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.submenu a:hover,
+.submenu a:focus {
+    background: rgba(15, 64, 57, 0.08);
+    color: #0f4039;
+}
+
+.nav-item:hover > .submenu,
+.nav-item:focus-within > .submenu {
+    display: block;
+}
+
 .nav-link {
     color: white;
     text-decoration: none;
@@ -4345,6 +4389,21 @@ body {
 
     .nav-menu.active .nav-link {
         width: 100%;
+    }
+
+    .nav-menu.active .submenu {
+        display: block;
+        position: static;
+        min-width: unset;
+        padding: 0.25rem 0 0.5rem;
+        margin-top: 0.35rem;
+        background: transparent;
+        border: none;
+        box-shadow: none;
+    }
+
+    .nav-menu.active .submenu a {
+        padding: 0.35rem 0 0.35rem 1rem;
     }
 
     .hamburger {


### PR DESCRIPTION
### Motivation
- Provide a persistent top navigation on the breathing home page so users can quickly access other important site pages and grouped tools.
- Support grouped links with dropdown submenus so related pages (tools, clocks, practices, profiles) are discoverable from the header.
- Keep the navigation accessible and usable on mobile by integrating with the existing hamburger behavior.

### Description
- Inserted a fixed `nav` block into `index.html` containing `ul.nav-menu` items and `li.has-submenu` groups with `aria-label` attributes and a hamburger `button` for mobile toggling.
- Added submenu styling and interaction CSS in `styles.css` including `.nav-item`, `.has-submenu > .nav-link::after`, `.submenu` and responsive rules under `@media (max-width: 768px)` to expose submenus inside the mobile menu.
- Kept changes localized to `index.html` and `styles.css` so existing JS navigation initialization (`initNavigation`) continues to handle the hamburger/menu open state.

### Testing
- Launched a local static server with `python -m http.server` and verified the site served successfully.
- Ran a Playwright script to load `http://127.0.0.1:8000/index.html` and capture a screenshot (`artifacts/index-nav.png`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962e3ee83f0832196287d95c1e8949d)